### PR TITLE
Refactors CONTRIBUTING.md.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,35 +6,7 @@ Let's do this! 🤓
 
 ## How do I report a bug?
 
-Hey, nobody's perfect. As much as we test our code, a few bugs sneak past us. If you would like to report one you found, simply check our [Github issues](https://github.com/freerware/work/issues) that have the `bug` tag to see if someone beat you to it! Otherwise, whip one up with the following template:
-
-```
-## Description
-
-[Description of the issue]
-
-## Steps to Reproduce
-
-1. [First Step]
-2. [Second Step]
-3. [and so on...]
-
-## Expected behavior: [What you expect to happen]
-
-## Actual behavior: [What actually happens]
-
-## Versions
-
-It can be super helpful to get an idea of your environment when troubleshooting issues. We ask you include the following versions:
-
-- `Go` (`go version`)
-- `dep` (`dep version`)
-- the version of `work` you are using
-
-## Additional Information
-
-Any additional information, configuration or data that might be necessary to reproduce the issue.
-```
+Hey, nobody's perfect. As much as we test our code, a few bugs sneak past us. If you would like to report one you found, simply check our [Github issues](https://github.com/freerware/work/issues) that have the `bug` tag to see if someone beat you to it! Otherwise, whip one up with [this](https://github.com/freerware/work/issues/new?assignees=freerjm&labels=bug&template=bug_report.md) template.
 
 ## How do I ask questions?
 
@@ -42,7 +14,7 @@ Great question. We suggest checking for any Github issues with the `question` ta
 
 ## Where can I leave feedback?
 
-We would enjoy hearing your thoughts on the work we have done so far, how you use `work`, and ideas you might have to make things better! Currently, just drop an email to the primary author at `freerjm@miamioh.edu`.
+We would enjoy hearing your thoughts on the work we have done so far, how you use `work`, and ideas you might have to make things better! Currently, just drop an email to the primary author at `freerware@gmail.com`.
 
 ## How do I contribute changes?
 
@@ -51,22 +23,5 @@ Want to lend us a hand? We welcome pull requests for fixes and new features! All
 - [ ] Uses [well formed commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
 - [ ] Includes unit tests and maintains consistent or higher code coverage.
 - [ ] Makes changes to both comments and other documentation where appropriate.
-- [ ] Uses the following pull request template:
+- [ ] Uses the following pull request [template](https://github.com/freerware/work/blob/master/.github/pull_request_template.md).
 
-```
-## Description
-
-[Description of the enhancement]
-
-## Rationale
-
-[Rationale of why consumers need this feature or fix]
-
-## Suggested Version
-
-[Dialog describing whether the change requires a bump in major, minor, or patch version number]
-
-## Example Usage
-
-[Walkthrough with code blocks to demonstrate the feature or fix]
-```


### PR DESCRIPTION
**Description**

- Refactors the `CONTRIBUTING.md` file to reference the newly introduced pull request and bug report templates, as well as to point to `freerware@gmail.com` for feedback.

**Rationale**

- Removes embedded template definition in favor of native Github support for templates.
- Ensures that feedback is routed to the appropriate email address.

**Suggested Version**

- No changes here.

**Example Usage**

- Not applicable.
