### PR TITLE
Introduce tally support.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -55,6 +55,14 @@
   version = "v1.3.0"
 
 [[projects]]
+  digest = "1:fdcd00d11e3c9d307f82e2cc8cd84fe8974ccc3053c2126be5553a38eb565760"
+  name = "github.com/uber-go/tally"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "f266f90e9c4d5894364039a324a05d061f2f34e2"
+  version = "v3.3.11"
+
+[[projects]]
   digest = "1:3c1a69cdae3501bf75e76d0d86dc6f2b0a7421bc205c0cb7b96b19eed464a34d"
   name = "go.uber.org/atomic"
   packages = ["."]
@@ -93,6 +101,7 @@
     "github.com/freerware/work/mocks",
     "github.com/stretchr/testify/mock",
     "github.com/stretchr/testify/suite",
+    "github.com/uber-go/tally",
     "go.uber.org/multierr",
     "go.uber.org/zap",
   ]

--- a/best_effort_unit.go
+++ b/best_effort_unit.go
@@ -18,8 +18,15 @@ package work
 import (
 	"fmt"
 
+	"github.com/uber-go/tally"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
+)
+
+var (
+	bestEffortUnitTag map[string]string = map[string]string{
+		"unit_type": "best_effort",
+	}
 )
 
 type bestEffortUnit struct {
@@ -43,71 +50,92 @@ func NewBestEffortUnit(parameters UnitParameters) Unit {
 		successfulUpdates: make(map[TypeName][]interface{}),
 		successfulDeletes: make(map[TypeName][]interface{}),
 	}
+
+	if u.hasScope() {
+		u.scope = u.scope.Tagged(bestEffortUnitTag)
+	}
 	return &u
 }
 
-func (u *bestEffortUnit) rollbackInserts() error {
+func (u *bestEffortUnit) rollbackInserts() (err error) {
 
 	//delete successfully inserted entities.
 	u.logDebug("attempting to rollback inserted entities",
 		zap.Int("count", u.successfulInsertCount))
 	for typeName, inserts := range u.successfulInserts {
-		if err := u.deleters[typeName].Delete(inserts...); err != nil {
+		if err = u.deleters[typeName].Delete(inserts...); err != nil {
 			u.logError(err.Error(), zap.String("typeName", typeName.String()))
-			return err
+			return
 		}
 	}
 	return nil
 }
 
-func (u *bestEffortUnit) rollbackUpdates() error {
+func (u *bestEffortUnit) rollbackUpdates() (err error) {
 
 	//reapply previously registered state for the entities.
 	u.logDebug("attempting to rollback updated entities",
 		zap.Int("count", u.successfulUpdateCount))
 	for typeName, r := range u.registered {
-		if err := u.updaters[typeName].Update(r...); err != nil {
+		if err = u.updaters[typeName].Update(r...); err != nil {
 			u.logError(err.Error(), zap.String("typeName", typeName.String()))
-			return err
+			return
 		}
 	}
-	return nil
+	return
 }
 
-func (u *bestEffortUnit) rollbackDeletes() error {
+func (u *bestEffortUnit) rollbackDeletes() (err error) {
 
 	//reinsert successfully deleted entities.
 	u.logDebug("attempting to rollback deleted entities",
 		zap.Int("count", u.successfulDeleteCount))
 	for typeName, deletes := range u.successfulDeletes {
-		if err := u.inserters[typeName].Insert(deletes...); err != nil {
+		if err = u.inserters[typeName].Insert(deletes...); err != nil {
 			u.logError(err.Error(), zap.String("typeName", typeName.String()))
-			return err
+			return
 		}
 	}
-	return nil
+	return
 }
 
-func (u *bestEffortUnit) rollback() error {
-	if err := u.rollbackDeletes(); err != nil {
-		return err
+func (u *bestEffortUnit) rollback() (err error) {
+
+	//setup timer.
+	if u.hasScope() {
+		stopWatch := u.scope.Timer("rollback").Start()
+		defer func() {
+			stopWatch.Stop()
+			if err != nil {
+				u.scope.Counter("rollback.failure").Inc(1)
+			} else {
+				u.scope.Counter("rollback.success").Inc(1)
+			}
+		}()
 	}
 
-	if err := u.rollbackUpdates(); err != nil {
-		return err
+	if err = u.rollbackDeletes(); err != nil {
+		return
 	}
 
-	return u.rollbackInserts()
+	if err = u.rollbackUpdates(); err != nil {
+		return
+	}
+
+	if err = u.rollbackInserts(); err != nil {
+		return
+	}
+	return
 }
 
-func (u *bestEffortUnit) applyInserts() error {
+func (u *bestEffortUnit) applyInserts() (err error) {
 
 	u.logDebug("attempting to insert entities", zap.Int("count", len(u.additions)))
 	for typeName, additions := range u.additions {
-		if err := u.inserters[typeName].Insert(additions...); err != nil {
+		if err = u.inserters[typeName].Insert(additions...); err != nil {
 			err = multierr.Combine(err, u.rollback())
 			u.logError(err.Error(), zap.String("typeName", typeName.String()))
-			return err
+			return
 		}
 		if _, ok := u.successfulInserts[typeName]; !ok {
 			u.successfulInserts[typeName] = []interface{}{}
@@ -116,17 +144,17 @@ func (u *bestEffortUnit) applyInserts() error {
 			append(u.successfulInserts[typeName], additions...)
 		u.successfulInsertCount = u.successfulInsertCount + len(additions)
 	}
-	return nil
+	return
 }
 
-func (u *bestEffortUnit) applyUpdates() error {
+func (u *bestEffortUnit) applyUpdates() (err error) {
 
 	u.logDebug("attempting to update entities", zap.Int("count", len(u.alterations)))
 	for typeName, alterations := range u.alterations {
-		if err := u.updaters[typeName].Update(alterations...); err != nil {
+		if err = u.updaters[typeName].Update(alterations...); err != nil {
 			err = multierr.Combine(err, u.rollback())
 			u.logError(err.Error(), zap.String("typeName", typeName.String()))
-			return err
+			return
 		}
 		if _, ok := u.successfulUpdates[typeName]; !ok {
 			u.successfulUpdates[typeName] = []interface{}{}
@@ -135,17 +163,17 @@ func (u *bestEffortUnit) applyUpdates() error {
 			append(u.successfulUpdates[typeName], alterations...)
 		u.successfulUpdateCount = u.successfulUpdateCount + len(alterations)
 	}
-	return nil
+	return
 }
 
-func (u *bestEffortUnit) applyDeletes() error {
+func (u *bestEffortUnit) applyDeletes() (err error) {
 
 	u.logDebug("attempting to remove entities", zap.Int("count", len(u.removals)))
 	for typeName, removals := range u.removals {
-		if err := u.deleters[typeName].Delete(removals...); err != nil {
+		if err = u.deleters[typeName].Delete(removals...); err != nil {
 			err = multierr.Combine(err, u.rollback())
 			u.logError(err.Error(), zap.String("typeName", typeName.String()))
-			return err
+			return
 		}
 		if _, ok := u.successfulDeletes[typeName]; !ok {
 			u.successfulDeletes[typeName] = []interface{}{}
@@ -154,10 +182,22 @@ func (u *bestEffortUnit) applyDeletes() error {
 			append(u.successfulDeletes[typeName], removals...)
 		u.successfulDeleteCount = u.successfulDeleteCount + len(removals)
 	}
-	return nil
+	return
 }
 
 func (u *bestEffortUnit) Save() (err error) {
+
+	//setup timer.
+	var stopWatch tally.Stopwatch
+	if u.hasScope() {
+		stopWatch = u.scope.Timer("save").Start()
+		defer func() {
+			stopWatch.Stop()
+			if err == nil {
+				u.scope.Counter("save.success").Inc(1)
+			}
+		}()
+	}
 
 	//rollback if there is a panic.
 	defer func() {

--- a/best_effort_unit_test.go
+++ b/best_effort_unit_test.go
@@ -2,11 +2,13 @@ package work
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/freerware/work/mocks"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 )
 
@@ -20,6 +22,21 @@ type BestEffortUnitTestSuite struct {
 	inserters map[TypeName]*mocks.Inserter
 	updaters  map[TypeName]*mocks.Updater
 	deleters  map[TypeName]*mocks.Deleter
+	scope     tally.TestScope
+
+	// metrics scope names and tags.
+	scopePrefix                      string
+	saveScopeName                    string
+	saveSuccessScopeName             string
+	saveScopeNameWithTags            string
+	saveSuccessScopeNameWithTags     string
+	rollbackScopeNameWithTags        string
+	rollbackSuccessScopeNameWithTags string
+	rollbackFailureScopeNameWithTags string
+	rollbackScopeName                string
+	rollbackFailureScopeName         string
+	rollbackSuccessScopeName         string
+	tags                             string
 }
 
 func TestBestEffortUnitTestSuite(t *testing.T) {
@@ -27,6 +44,21 @@ func TestBestEffortUnitTestSuite(t *testing.T) {
 }
 
 func (s *BestEffortUnitTestSuite) SetupTest() {
+
+	// initialize metric names.
+	sep := "+"
+	s.scopePrefix = "test"
+	s.tags = "unit_type=best_effort"
+	s.saveScopeName = fmt.Sprintf("%s.%s", s.scopePrefix, "unit.save")
+	s.saveScopeNameWithTags = fmt.Sprintf("%s%s%s", s.saveScopeName, sep, s.tags)
+	s.rollbackScopeName = fmt.Sprintf("%s.%s", s.scopePrefix, "unit.rollback")
+	s.rollbackScopeNameWithTags = fmt.Sprintf("%s%s%s", s.rollbackScopeName, sep, s.tags)
+	s.saveSuccessScopeName = fmt.Sprintf("%s.success", s.saveScopeName)
+	s.rollbackSuccessScopeName = fmt.Sprintf("%s.success", s.rollbackScopeName)
+	s.rollbackFailureScopeName = fmt.Sprintf("%s.failure", s.rollbackScopeName)
+	s.saveSuccessScopeNameWithTags = fmt.Sprintf("%s%s%s", s.saveSuccessScopeName, sep, s.tags)
+	s.rollbackSuccessScopeNameWithTags = fmt.Sprintf("%s%s%s", s.rollbackSuccessScopeName, sep, s.tags)
+	s.rollbackFailureScopeNameWithTags = fmt.Sprintf("%s%s%s", s.rollbackFailureScopeName, sep, s.tags)
 
 	// test entities.
 	foo := Foo{ID: 28}
@@ -59,13 +91,18 @@ func (s *BestEffortUnitTestSuite) SetupTest() {
 		d[t] = m
 	}
 
-	l, _ := zap.NewDevelopment()
+	c := zap.NewDevelopmentConfig()
+	c.DisableStacktrace = true
+	l, _ := c.Build()
+	ts := tally.NewTestScope(s.scopePrefix, map[string]string{})
 	params := UnitParameters{
 		Inserters: i,
 		Updaters:  u,
 		Deleters:  d,
 		Logger:    l,
+		Scope:     ts,
 	}
+	s.scope = ts
 	s.sut = NewBestEffortUnit(params)
 }
 
@@ -95,7 +132,7 @@ func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save_InserterError() {
 	alterError := s.sut.Alter(updatedEntities...)
 	removeError := s.sut.Remove(removedEntities...)
 	err := errors.New("whoa")
-	s.inserters[fooType].On("Insert", addedEntities[0]).Return(err)
+	s.inserters[fooType].On("Insert", addedEntities[0]).Return(nil)
 	s.inserters[barType].On("Insert", addedEntities[1]).Return(err)
 
 	// arrange - rollback invocations.
@@ -115,6 +152,11 @@ func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save_InserterError() {
 	s.Require().NoError(alterError)
 	s.Require().NoError(removeError)
 	s.Error(err)
+	s.Len(s.scope.Snapshot().Counters(), 1)
+	s.Contains(s.scope.Snapshot().Counters(), s.rollbackSuccessScopeNameWithTags)
+	s.Len(s.scope.Snapshot().Timers(), 2)
+	s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
+	s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)
 }
 
 func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save_InserterAndRollbackError() {
@@ -162,6 +204,11 @@ func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save_InserterAndRollbackErr
 	s.Require().NoError(alterError)
 	s.Require().NoError(removeError)
 	s.Error(err)
+	s.Len(s.scope.Snapshot().Counters(), 1)
+	s.Contains(s.scope.Snapshot().Counters(), s.rollbackFailureScopeNameWithTags)
+	s.Len(s.scope.Snapshot().Timers(), 2)
+	s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
+	s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)
 }
 
 func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save_UpdaterError() {
@@ -192,8 +239,8 @@ func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save_UpdaterError() {
 	err := errors.New("whoa")
 	s.inserters[fooType].On("Insert", addedEntities[0]).Return(nil)
 	s.inserters[barType].On("Insert", addedEntities[1]).Return(nil)
-	s.updaters[barType].On("Update", updatedEntities[1]).Return(err)
-	s.updaters[fooType].On("Update", updatedEntities[0]).Return(err)
+	s.updaters[barType].On("Update", updatedEntities[1]).Return(err).Once()
+	s.updaters[fooType].On("Update", updatedEntities[0]).Return(nil)
 
 	// arrange - rollback invocations.
 	s.inserters[fooType].On("Insert", removedEntities[0]).Return(nil)
@@ -212,6 +259,11 @@ func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save_UpdaterError() {
 	s.Require().NoError(alterError)
 	s.Require().NoError(removeError)
 	s.Error(err)
+	s.Len(s.scope.Snapshot().Counters(), 1)
+	s.Contains(s.scope.Snapshot().Counters(), s.rollbackSuccessScopeNameWithTags)
+	s.Len(s.scope.Snapshot().Timers(), 2)
+	s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
+	s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)
 }
 
 func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save_UpdaterAndRollbackError() {
@@ -241,6 +293,7 @@ func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save_UpdaterAndRollbackErro
 	removeError := s.sut.Remove(removedEntities...)
 	err := errors.New("whoa")
 	s.inserters[fooType].On("Insert", addedEntities[0]).Return(nil)
+	s.inserters[barType].On("Insert", addedEntities[1]).Return(nil)
 	s.updaters[fooType].On("Update", updatedEntities[0]).Return(err)
 
 	// arrange - rollback invocations.
@@ -311,6 +364,11 @@ func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save_DeleterError() {
 	s.Require().NoError(alterError)
 	s.Require().NoError(removeError)
 	s.Error(err)
+	s.Len(s.scope.Snapshot().Counters(), 1)
+	s.Contains(s.scope.Snapshot().Counters(), s.rollbackSuccessScopeNameWithTags)
+	s.Len(s.scope.Snapshot().Timers(), 2)
+	s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
+	s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)
 }
 
 func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save_DeleterAndRollbackError() {
@@ -340,6 +398,7 @@ func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save_DeleterAndRollbackErro
 	removeError := s.sut.Remove(removedEntities...)
 	err := errors.New("whoa")
 	s.inserters[fooType].On("Insert", addedEntities[0]).Return(nil)
+	s.inserters[barType].On("Insert", addedEntities[1]).Return(nil)
 	s.updaters[fooType].On("Update", updatedEntities[0]).Return(nil)
 	s.updaters[barType].On("Update", updatedEntities[1]).Return(nil)
 	s.deleters[fooType].On("Delete", removedEntities[0]).Return(err)
@@ -361,6 +420,11 @@ func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save_DeleterAndRollbackErro
 	s.Require().NoError(alterError)
 	s.Require().NoError(removeError)
 	s.Error(err)
+	s.Len(s.scope.Snapshot().Counters(), 1)
+	s.Contains(s.scope.Snapshot().Counters(), s.rollbackFailureScopeNameWithTags)
+	s.Len(s.scope.Snapshot().Timers(), 2)
+	s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
+	s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)
 }
 
 func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save_Panic() {
@@ -390,6 +454,7 @@ func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save_Panic() {
 	removeError := s.sut.Remove(removedEntities...)
 	err := errors.New("whoa")
 	s.inserters[fooType].On("Insert", addedEntities[0]).Return(nil)
+	s.inserters[barType].On("Insert", addedEntities[1]).Return(nil)
 	s.updaters[fooType].On("Update", updatedEntities[0]).Return(nil)
 	s.updaters[barType].On("Update", updatedEntities[1]).Return(nil)
 	s.deleters[fooType].
@@ -413,6 +478,11 @@ func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save_Panic() {
 	s.Require().NoError(alterError)
 	s.Require().NoError(removeError)
 	s.Error(err)
+	s.Len(s.scope.Snapshot().Counters(), 1)
+	s.Contains(s.scope.Snapshot().Counters(), s.rollbackSuccessScopeNameWithTags)
+	s.Len(s.scope.Snapshot().Timers(), 2)
+	s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
+	s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)
 }
 
 func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save_PanicAndRollbackError() {
@@ -442,8 +512,9 @@ func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save_PanicAndRollbackError(
 	removeError := s.sut.Remove(removedEntities...)
 	err := errors.New("whoa")
 	s.inserters[fooType].On("Insert", addedEntities[0]).Return(nil)
+	s.inserters[barType].On("Insert", addedEntities[1]).Return(nil)
 	s.updaters[fooType].On("Update", updatedEntities[0]).Return(nil)
-	s.updaters[barType].On("Update", updatedEntities[1]).Return(nil)
+	s.updaters[barType].On("Update", updatedEntities[1]).Return(nil).Once()
 	s.deleters[fooType].
 		On("Delete", removedEntities[0]).
 		Return().Run(func(args mock.Arguments) { panic("whoa") })
@@ -465,6 +536,11 @@ func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save_PanicAndRollbackError(
 	s.Require().NoError(alterError)
 	s.Require().NoError(removeError)
 	s.Error(err)
+	s.Len(s.scope.Snapshot().Counters(), 1)
+	s.Contains(s.scope.Snapshot().Counters(), s.rollbackFailureScopeNameWithTags)
+	s.Len(s.scope.Snapshot().Timers(), 2)
+	s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
+	s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)
 }
 
 func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save() {
@@ -500,6 +576,10 @@ func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save() {
 	s.Require().NoError(alterError)
 	s.Require().NoError(removeError)
 	s.NoError(err)
+	s.Len(s.scope.Snapshot().Counters(), 1)
+	s.Contains(s.scope.Snapshot().Counters(), s.saveSuccessScopeNameWithTags)
+	s.Len(s.scope.Snapshot().Timers(), 1)
+	s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
 }
 
 func (s *BestEffortUnitTestSuite) TearDownTest() {

--- a/sql_unit_test.go
+++ b/sql_unit_test.go
@@ -3,12 +3,14 @@ package work
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/freerware/work/mocks"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 )
 
@@ -21,9 +23,24 @@ type SQLUnitTestSuite struct {
 	// mocks.
 	db        *sql.DB
 	_db       sqlmock.Sqlmock
+	scope     tally.TestScope
 	inserters map[TypeName]*mocks.Inserter
 	updaters  map[TypeName]*mocks.Updater
 	deleters  map[TypeName]*mocks.Deleter
+
+	// metrics scope names and tags.
+	scopePrefix                      string
+	saveScopeName                    string
+	saveSuccessScopeName             string
+	saveScopeNameWithTags            string
+	saveSuccessScopeNameWithTags     string
+	rollbackScopeNameWithTags        string
+	rollbackSuccessScopeNameWithTags string
+	rollbackFailureScopeNameWithTags string
+	rollbackScopeName                string
+	rollbackFailureScopeName         string
+	rollbackSuccessScopeName         string
+	tags                             string
 }
 
 func TestSQLUnitTestSuite(t *testing.T) {
@@ -31,6 +48,21 @@ func TestSQLUnitTestSuite(t *testing.T) {
 }
 
 func (s *SQLUnitTestSuite) SetupTest() {
+
+	// initialize metric names.
+	sep := "+"
+	s.scopePrefix = "test"
+	s.tags = "unit_type=sql"
+	s.saveScopeName = fmt.Sprintf("%s.%s", s.scopePrefix, "unit.save")
+	s.saveScopeNameWithTags = fmt.Sprintf("%s%s%s", s.saveScopeName, sep, s.tags)
+	s.rollbackScopeName = fmt.Sprintf("%s.%s", s.scopePrefix, "unit.rollback")
+	s.rollbackScopeNameWithTags = fmt.Sprintf("%s%s%s", s.rollbackScopeName, sep, s.tags)
+	s.saveSuccessScopeName = fmt.Sprintf("%s.success", s.saveScopeName)
+	s.rollbackSuccessScopeName = fmt.Sprintf("%s.success", s.rollbackScopeName)
+	s.rollbackFailureScopeName = fmt.Sprintf("%s.failure", s.rollbackScopeName)
+	s.saveSuccessScopeNameWithTags = fmt.Sprintf("%s%s%s", s.saveSuccessScopeName, sep, s.tags)
+	s.rollbackSuccessScopeNameWithTags = fmt.Sprintf("%s%s%s", s.rollbackSuccessScopeName, sep, s.tags)
+	s.rollbackFailureScopeNameWithTags = fmt.Sprintf("%s%s%s", s.rollbackFailureScopeName, sep, s.tags)
 
 	// test entities.
 	foo := Foo{ID: 28}
@@ -67,16 +99,21 @@ func (s *SQLUnitTestSuite) SetupTest() {
 		d[t] = m
 	}
 
-	l, _ := zap.NewDevelopment()
+	c := zap.NewDevelopmentConfig()
+	c.DisableStacktrace = true
+	l, _ := c.Build()
+	ts := tally.NewTestScope(s.scopePrefix, map[string]string{})
 	params := SQLUnitParameters{
 		UnitParameters: UnitParameters{
 			Inserters: i,
 			Updaters:  u,
 			Deleters:  d,
 			Logger:    l,
+			Scope:     ts,
 		},
 		ConnectionPool: s.db,
 	}
+	s.scope = ts
 	s.sut, err = NewSQLUnit(params)
 	s.Require().NoError(err)
 }
@@ -109,6 +146,10 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Save_TransactionBeginError() {
 	s.Require().NoError(removeError)
 	s.Require().NoError(s._db.ExpectationsWereMet())
 	s.Error(err)
+	s.Len(s.scope.Snapshot().Counters(), 1)
+	s.Contains(s.scope.Snapshot().Counters(), s.rollbackSuccessScopeNameWithTags)
+	s.Len(s.scope.Snapshot().Timers(), 1)
+	s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
 }
 
 func (s *SQLUnitTestSuite) TestSQLUnit_Save_InserterError() {
@@ -150,6 +191,11 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Save_InserterError() {
 	s.Require().NoError(removeError)
 	s.Require().NoError(s._db.ExpectationsWereMet())
 	s.Error(err)
+	s.Len(s.scope.Snapshot().Counters(), 1)
+	s.Contains(s.scope.Snapshot().Counters(), s.rollbackSuccessScopeNameWithTags)
+	s.Len(s.scope.Snapshot().Timers(), 2)
+	s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
+	s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)
 }
 
 func (s *SQLUnitTestSuite) TestSQLUnit_Save_InserterAndRollbackError() {
@@ -191,6 +237,11 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Save_InserterAndRollbackError() {
 	s.Require().NoError(removeError)
 	s.Require().NoError(s._db.ExpectationsWereMet())
 	s.Error(err)
+	s.Len(s.scope.Snapshot().Counters(), 1)
+	s.Contains(s.scope.Snapshot().Counters(), s.rollbackFailureScopeNameWithTags)
+	s.Len(s.scope.Snapshot().Timers(), 2)
+	s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
+	s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)
 }
 func (s *SQLUnitTestSuite) TestSQLUnit_Save_UpdaterError() {
 
@@ -239,6 +290,11 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Save_UpdaterError() {
 	s.Require().NoError(removeError)
 	s.Require().NoError(s._db.ExpectationsWereMet())
 	s.Error(err)
+	s.Len(s.scope.Snapshot().Counters(), 1)
+	s.Contains(s.scope.Snapshot().Counters(), s.rollbackSuccessScopeNameWithTags)
+	s.Len(s.scope.Snapshot().Timers(), 2)
+	s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
+	s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)
 }
 
 func (s *SQLUnitTestSuite) TestSQLUnit_Save_UpdaterAndRollbackError() {
@@ -288,6 +344,11 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Save_UpdaterAndRollbackError() {
 	s.Require().NoError(removeError)
 	s.Require().NoError(s._db.ExpectationsWereMet())
 	s.Error(err)
+	s.Len(s.scope.Snapshot().Counters(), 1)
+	s.Contains(s.scope.Snapshot().Counters(), s.rollbackFailureScopeNameWithTags)
+	s.Len(s.scope.Snapshot().Timers(), 2)
+	s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
+	s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)
 }
 
 func (s *SQLUnitTestSuite) TestSQLUnit_Save_DeleterError() {
@@ -341,6 +402,11 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Save_DeleterError() {
 	s.Require().NoError(removeError)
 	s.Require().NoError(s._db.ExpectationsWereMet())
 	s.Error(err)
+	s.Len(s.scope.Snapshot().Counters(), 1)
+	s.Contains(s.scope.Snapshot().Counters(), s.rollbackSuccessScopeNameWithTags)
+	s.Len(s.scope.Snapshot().Timers(), 2)
+	s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
+	s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)
 }
 
 func (s *SQLUnitTestSuite) TestSQLUnit_Save_DeleterAndRollbackError() {
@@ -394,6 +460,11 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Save_DeleterAndRollbackError() {
 	s.Require().NoError(removeError)
 	s.Require().NoError(s._db.ExpectationsWereMet())
 	s.Error(err)
+	s.Len(s.scope.Snapshot().Counters(), 1)
+	s.Contains(s.scope.Snapshot().Counters(), s.rollbackFailureScopeNameWithTags)
+	s.Len(s.scope.Snapshot().Timers(), 2)
+	s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
+	s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)
 }
 
 func (s *SQLUnitTestSuite) TestSQLUnit_Save_Panic() {
@@ -447,6 +518,11 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Save_Panic() {
 	s.Require().NoError(removeError)
 	s.Require().NoError(s._db.ExpectationsWereMet())
 	s.Error(err)
+	s.Len(s.scope.Snapshot().Counters(), 1)
+	s.Contains(s.scope.Snapshot().Counters(), s.rollbackFailureScopeNameWithTags)
+	s.Len(s.scope.Snapshot().Timers(), 2)
+	s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
+	s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)
 }
 
 func (s *SQLUnitTestSuite) TestSQLUnit_Save_PanicAndRollbackError() {
@@ -469,7 +545,7 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Save_PanicAndRollbackError() {
 	alterError := s.sut.Alter(updatedEntities...)
 	removeError := s.sut.Remove(removedEntities...)
 	s._db.ExpectBegin()
-	s._db.ExpectRollback()
+	s._db.ExpectRollback().WillReturnError(errors.New("whoa"))
 	s.inserters[fooType].On(
 		"Insert",
 		addedEntities[0],
@@ -500,6 +576,11 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Save_PanicAndRollbackError() {
 	s.Require().NoError(removeError)
 	s.Require().NoError(s._db.ExpectationsWereMet())
 	s.Error(err)
+	s.Len(s.scope.Snapshot().Counters(), 1)
+	s.Contains(s.scope.Snapshot().Counters(), s.rollbackFailureScopeNameWithTags)
+	s.Len(s.scope.Snapshot().Timers(), 2)
+	s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
+	s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)
 }
 
 func (s *SQLUnitTestSuite) TestSQLUnit_Save_CommitError() {
@@ -553,6 +634,10 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Save_CommitError() {
 	s.Require().NoError(removeError)
 	s.Require().NoError(s._db.ExpectationsWereMet())
 	s.Error(err)
+	s.Len(s.scope.Snapshot().Counters(), 1)
+	s.Contains(s.scope.Snapshot().Counters(), s.rollbackSuccessScopeNameWithTags)
+	s.Len(s.scope.Snapshot().Timers(), 1)
+	s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
 }
 
 func (s *SQLUnitTestSuite) TestSQLUnit_Save() {
@@ -606,9 +691,14 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Save() {
 	s.Require().NoError(removeError)
 	s.Require().NoError(s._db.ExpectationsWereMet())
 	s.NoError(err)
+	s.Len(s.scope.Snapshot().Counters(), 1)
+	s.Contains(s.scope.Snapshot().Counters(), s.saveSuccessScopeNameWithTags)
+	s.Len(s.scope.Snapshot().Timers(), 1)
+	s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
 }
 
 func (s *SQLUnitTestSuite) TearDownTest() {
 	s.db.Close()
 	s.sut = nil
+	s.scope = nil
 }

--- a/unit.go
+++ b/unit.go
@@ -18,6 +18,7 @@ package work
 import (
 	"fmt"
 
+	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 )
 
@@ -53,9 +54,14 @@ type unit struct {
 	alterationCount int
 	removalCount    int
 	logger          *zap.Logger
+	scope           tally.Scope
 }
 
 func newUnit(parameters UnitParameters) unit {
+	var scope tally.Scope
+	if parameters.Scope != nil {
+		scope = parameters.Scope.SubScope("unit")
+	}
 	u := unit{
 		inserters:   parameters.Inserters,
 		updaters:    parameters.Updaters,
@@ -65,6 +71,7 @@ func newUnit(parameters UnitParameters) unit {
 		removals:    make(map[TypeName][]interface{}),
 		registered:  make(map[TypeName][]interface{}),
 		logger:      parameters.Logger,
+		scope:       scope,
 	}
 	return u
 }
@@ -89,6 +96,10 @@ func (u *unit) logDebug(message string, fields ...zap.Field) {
 	if u.hasLogger() {
 		u.logger.Debug(message, fields...)
 	}
+}
+
+func (u *unit) hasScope() bool {
+	return u.scope != nil
 }
 
 // Register tracks the provided entities as clean.

--- a/unit_parameters.go
+++ b/unit_parameters.go
@@ -15,7 +15,10 @@
 
 package work
 
-import "go.uber.org/zap"
+import (
+	"github.com/uber-go/tally"
+	"go.uber.org/zap"
+)
 
 // UnitParameters represents the collection of
 // dependencies and configuration needed for a work unit.
@@ -35,4 +38,7 @@ type UnitParameters struct {
 
 	//Logger represents the logger that the work unit will utilize.
 	Logger *zap.Logger
+
+	//Scope represents the metric scope that the work unit will utilize.
+	Scope tally.Scope
 }

--- a/unit_test.go
+++ b/unit_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/freerware/work/mocks"
 	"github.com/stretchr/testify/suite"
+	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 )
 
@@ -65,12 +66,16 @@ func (s *UnitTestSuite) SetupTest() {
 		d[t] = m
 	}
 
-	l, _ := zap.NewDevelopment()
+	c := zap.NewDevelopmentConfig()
+	c.DisableStacktrace = true
+	l, _ := c.Build()
+	m := tally.NewTestScope("test", map[string]string{})
 	params := UnitParameters{
 		Inserters: i,
 		Updaters:  u,
 		Deleters:  d,
 		Logger:    l,
+		Scope:     m,
 	}
 	s.sut = newUnit(params)
 }


### PR DESCRIPTION
**Description**

- Introduce metric support using [`tally`](https://github.com/uber-go/tally).
- Emit several metrics within the work units (names based off of [this strategy](https://matt.aimonetti.net/posts/2013-06-practical-guide-to-graphite-monitoring/)):
  - `unit.save` (timer) -> The amount of time it takes for the unit to save.
  - `unit.save.success` (counter) -> The number of successful unit saves.
  - `unit.rollback` (timer) -> The amount of time it takes for the unit to rollback.
  - `unit.rollback.success` (counter) -> The number of successful unit rollbacks.
  - `unit.rollback.failure` (counter) -> The number of unsuccessful unit rollbacks.
- Additional cleanup:
  - Consistent usage of named return arguments.
  - Disabling of stacktraces in unit test error logs.
  - Fixed broken unit tests with panicking mocks.

**Rationale**

- Work units are responsible for managing mission critical aspects of the application, orchestrating the persistence of changed entities, as well as handling error scenarios and rolling back accordingly. As such, consumers should expect the ability to gain observability into how their work units are performing.

**Suggested Version**

`v1.1.0`

**Example Usage**

When constructing instances of work units or uniters, consumers provide an instance of [`tally.Scope`](https://godoc.org/github.com/uber-go/tally#Scope), like so:

```go
c := zap.NewDevelopmentConfig()
c.DisableStacktrace = true
l, _ := c.Build()
m := tally.NewTestScope("test", map[string]string{}) // <--
params := SQLUnitParameters{
  UnitParameters: UnitParameters{
    Inserters: i,
    Updaters:  u,
    Deleters:  d,
    Logger:    l,
    Scope:     m, // <--
  },
  ConnectionPool: s.db,
}
```