### PR TITLE
Pass through panics instead transforming them into errors.

### DIFF
--- a/best_effort_unit.go
+++ b/best_effort_unit.go
@@ -206,6 +206,7 @@ func (u *bestEffortUnit) Save() (err error) {
 				fmt.Errorf("panic: unable to save work unit\n%v", r), u.rollback())
 			u.logError("panic: unable to save work unit",
 				zap.String("panic", fmt.Sprintf("%v", r)))
+			panic(r)
 		}
 	}()
 

--- a/sql_unit.go
+++ b/sql_unit.go
@@ -149,6 +149,7 @@ func (u *sqlUnit) Save() (err error) {
 				fmt.Errorf("panic: unable to save work unit\n%v", r), u.rollback(tx))
 			u.logError("panic: unable to save work unit",
 				zap.String("panic", fmt.Sprintf("%v", r)))
+			panic(r)
 		}
 	}()
 

--- a/sql_unit_test.go
+++ b/sql_unit_test.go
@@ -509,15 +509,12 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Save_Panic() {
 		removedEntities[0],
 	).Return().Run(func(args mock.Arguments) { panic("whoa") })
 
-	// action.
-	err := s.sut.Save()
-
-	// assert.
+	// action + assert.
+	s.Require().Panics(func() { s.sut.Save() })
 	s.Require().NoError(addError)
 	s.Require().NoError(alterError)
 	s.Require().NoError(removeError)
 	s.Require().NoError(s._db.ExpectationsWereMet())
-	s.Error(err)
 	s.Len(s.scope.Snapshot().Counters(), 1)
 	s.Contains(s.scope.Snapshot().Counters(), s.rollbackFailureScopeNameWithTags)
 	s.Len(s.scope.Snapshot().Timers(), 2)
@@ -567,15 +564,12 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Save_PanicAndRollbackError() {
 		removedEntities[0],
 	).Return().Run(func(args mock.Arguments) { panic("whoa") })
 
-	// action.
-	err := s.sut.Save()
-
-	// assert.
+	// action + assert.
+	s.Require().Panics(func() { s.sut.Save() })
 	s.Require().NoError(addError)
 	s.Require().NoError(alterError)
 	s.Require().NoError(removeError)
 	s.Require().NoError(s._db.ExpectationsWereMet())
-	s.Error(err)
 	s.Len(s.scope.Snapshot().Counters(), 1)
 	s.Contains(s.scope.Snapshot().Counters(), s.rollbackFailureScopeNameWithTags)
 	s.Len(s.scope.Snapshot().Timers(), 2)
@@ -633,7 +627,7 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Save_CommitError() {
 	s.Require().NoError(alterError)
 	s.Require().NoError(removeError)
 	s.Require().NoError(s._db.ExpectationsWereMet())
-	s.Error(err)
+	s.Require().Error(err)
 	s.Len(s.scope.Snapshot().Counters(), 1)
 	s.Contains(s.scope.Snapshot().Counters(), s.rollbackSuccessScopeNameWithTags)
 	s.Len(s.scope.Snapshot().Timers(), 1)


### PR DESCRIPTION
**Description**

Instead of recovering from panics and returning an `error`, these changes appropriately recover from a `panic` to execute rollbacks and log, but then passthrough the `panic`.

**Rationale**

Consumers of the package should be in control of how to handle panics when they occur. The main purpose of recovering from the panics within package is to ensure changes are rolled back when panics occur. It is possible to accomplish this need, but also ensure transparency of the package when panics occur by passing through the panic after a successful rollback.

**Suggested Version**

`v1.2.0`

**Example Usage**

There are no changes to the packages API, so an example is not applicable.
