### PR TITLE
Recover from rollback panics.

### DIFF
--- a/sql_unit_test.go
+++ b/sql_unit_test.go
@@ -487,7 +487,7 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Save_Panic() {
 	alterError := s.sut.Alter(updatedEntities...)
 	removeError := s.sut.Remove(removedEntities...)
 	s._db.ExpectBegin()
-	s._db.ExpectRollback().WillReturnError(errors.New("whoa"))
+	s._db.ExpectRollback()
 	s.inserters[fooType].On(
 		"Insert",
 		addedEntities[0],
@@ -516,7 +516,7 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Save_Panic() {
 	s.Require().NoError(removeError)
 	s.Require().NoError(s._db.ExpectationsWereMet())
 	s.Len(s.scope.Snapshot().Counters(), 1)
-	s.Contains(s.scope.Snapshot().Counters(), s.rollbackFailureScopeNameWithTags)
+	s.Contains(s.scope.Snapshot().Counters(), s.rollbackSuccessScopeNameWithTags)
 	s.Len(s.scope.Snapshot().Timers(), 2)
 	s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
 	s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)

--- a/unit.go
+++ b/unit.go
@@ -22,6 +22,14 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	rollbackSuccess = "rollback.success"
+	rollbackFailure = "rollback.failure"
+	saveSuccess     = "save.success"
+	save            = "save"
+	rollback        = "rollback"
+)
+
 // Unit represents an atomic set of entity changes.
 type Unit interface {
 
@@ -100,6 +108,20 @@ func (u *unit) logDebug(message string, fields ...zap.Field) {
 
 func (u *unit) hasScope() bool {
 	return u.scope != nil
+}
+
+func (u *unit) incrementCounter(name string, amount int64) {
+	if u.hasScope() {
+		u.scope.Counter(name).Inc(amount)
+	}
+}
+
+func (u *unit) startTimer(name string) func() {
+	var stopFunc func()
+	if u.hasScope() {
+		stopFunc = u.scope.Timer(name).Start().Stop
+	}
+	return stopFunc
 }
 
 // Register tracks the provided entities as clean.


### PR DESCRIPTION
**Description**

In certain situations, it is possible for a `panic` to occur during the rollback process. For example, within the `bestEffortUnit`, a panic surfaced from an `Inserter`, `Updater`, or `Deleter` during the normal flow of the save process can be resurfaced again since those same those types are used to rollback. These changes seek to recover that panic to appropriately log and capture metrics correctly.

**Rationale**

Recovering the panic within the rollback process ensures that logs and metrics are appropriately reflected in those scenarios. It’s critical that the logs and metrics are captured when this occurs, as it means that changes couldn’t be rolled back successfully and that the underlying data store is dirty.

**Suggested Version**

`v1.2.1`

**Example Usage**

There are no external changes to the packages API, so an example is not applicable.
