### PR TITLE
Return no-op stop function when not configured with work.UnitScope.

### DIFF
--- a/unit.go
+++ b/unit.go
@@ -120,7 +120,7 @@ func (u *unit) incrementCounter(name string, amount int64) {
 }
 
 func (u *unit) startTimer(name string) func() {
-	var stopFunc func()
+	stopFunc := func() {}
 	if u.hasScope() {
 		stopFunc = u.scope.Timer(name).Start().Stop
 	}


### PR DESCRIPTION
**Description**

Addresses #16.

**Rationale**

Without this fix, consumers of the package that do not leverage the `work.UnitScope(...)` option for their work units will be unable to save them successfully.

**Suggested Version**

`v2.0.1`

**Example Usage**

N/A - No new functionality has been added. This change purely fixes a bug.
