### PR TITLE
Fix up README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,19 @@
 # work
 > A compact library for tracking and committing atomic changes to your entities.
 
-[![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][coverage-img]][coverage] [![Release][release-img]][release] [![License][license-img]][license] [![Blog][blog-img]][blog]
+[![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci]
+[![Coverage Status][coverage-img]][coverage] [![Release][release-img]][release]
+[![License][license-img]][license] [![Blog][blog-img]][blog]
 
 ## What is it?
 
-`work` does the heavy lifting of tracking changes that your application makes to entities within
-a particular operation. This is accomplished using what we refer to as a "work unit", which is essentially
-an implementation of the [Unit Of Work][uow] pattern popularized by Martin Fowler.
-With work units, you no longer need to write any code to track, apply, or rollback changes atomically in your application.
-This lets you focus on just writing the code that handles changes when they happen.
+`work` does the heavy lifting of tracking changes that your application makes
+to entities within a particular operation. This is accomplished by using what we
+refer to as a "work unit", which is essentially an implementation of the
+[Unit Of Work][uow] pattern popularized by Martin Fowler. With work units,
+you no longer need to write any code to track, apply, or rollback changes
+atomically in your application. This lets you focus on just writing the code
+that handles changes when they happen.
 
 ## Why use it?
 
@@ -26,7 +30,10 @@ There are a bundle of benefits you get by using work units:
 
 ## How to use it?
 
-The following assumes your application has types (`fdm`, `bdm`) that satisfy the [`SQLDataMapper`][sql-data-mapper-doc] and [`DataMapper`][data-mapper-doc] interfaces, as well as [`*sql.DB`][db-doc] (`db`).
+The following assumes your application has a variable (`sdm`) of a type that
+satisfies [`work.SQLDataMapper`][sql-data-mapper-doc], a variable (`dm`) of
+a type that satisfies [`work.DataMapper`][data-mapper-doc], and a variable (`db`)
+of type [`*sql.DB`][db-doc].
 
 ### Construction
 
@@ -40,8 +47,8 @@ fType, bType :=
 we can create SQL work units:
 ```go
 mappers := map[work.TypeName]work.SQLDataMapper {
-	fType: fdm,
-	bType: bdm,
+	fType: sdm,
+	bType: sdm,
 }
 
 unit, err := work.NewSQLUnit(mappers, db)
@@ -53,8 +60,8 @@ if err != nil {
 or we can create "best effort" units:
 ```go
 mappers := map[work.TypeName]work.DataMapper {
-	fType: fdm,
-	bType: bdm,
+	fType: dm,
+	bType: dm,
 }
 
 unit, err := work.NewBestEffortUnit(mappers)
@@ -66,28 +73,29 @@ if err != nil {
 ### Adding
 When creating new entities, use [`Add`][unit-doc]:
 ```go
-additions := interface{}{Foo{}, Bar{}}
+additions := []interface{}{Foo{}, Bar{}}
 unit.Add(additions...)
 ```
 
 ### Updating
 When modifying existing entities, use [`Alter`][unit-doc]:
 ```go
-updates := interface{}{Foo{}, Bar{}}
+updates := []interface{}{Foo{}, Bar{}}
 unit.Alter(updates...)
 ```
 
 ### Removing
 When removing existing entities, use [`Remove`][unit-doc]:
 ```go
-removals := interface{}{Foo{}, Bar{}}
+removals := []interface{}{Foo{}, Bar{}}
 unit.Remove(removals...)
 ```
 
 ### Registering 
-When retrieving existing entities, track their intial state using [`Register`][unit-doc]:
+When retrieving existing entities, track their intial state using
+[`Register`][unit-doc]:
 ```go
-fetched := interface{}{Foo{}, Bar{}}
+fetched := []interface{}{Foo{}, Bar{}}
 unit.Register(fetched...)
 ```
 
@@ -100,7 +108,9 @@ if err := unit.Save(); err != nil {
 ```
 
 ### Logging
-We use [`zap`][zap] as our logging library of choice. To leverage the logs emitted from the work units, simply pass in an instance of [`*zap.Logger`][logger-doc] upon creation:
+We use [`zap`][zap] as our logging library of choice. To leverage the logs
+emitted from the work units, utilize the [`work.UnitLogger`][unit-logger-doc]
+option with an instance of [`*zap.Logger`][logger-doc] upon creation:
 ```go
 l, _ := zap.NewDevelopment()
 
@@ -112,7 +122,10 @@ if err != nil {
 ```
 
 ### Metrics
-For emitting metrics, we use [`tally`][tally]. To utilize the metrics emitted from the work units, pass in a [`Scope`][scope-doc] upon creation. Assuming we have an a scope `s`, it would look like so:
+For emitting metrics, we use [`tally`][tally]. To utilize the metrics emitted
+from the work units, leverage the [`work.UnitScope`][unit-scope-doc] option
+with a [`tally.Scope`][scope-doc] upon creation. Assuming we have a
+scope `s`, it would look like so:
 ```go
 unit, err := work.NewBestEffortUnit(mappers, work.UnitScope(s))
 if err != nil {
@@ -131,7 +144,10 @@ if err != nil {
 | [_PREFIX._]unit.rollback         | timer   | The time duration when rolling back a work unit. |
 
 ### Uniters
-In most circumstances, an application has many aspects that result in the creation of a work unit. To tackle that challenge, we recommend using [`Uniter`][uniter-doc]s to create instances of [`Unit`][unit-doc], like so:
+In most circumstances, an application has many aspects that result in the
+creation of a work unit. To tackle that challenge, we recommend using
+[`work.Uniter`][uniter-doc] to create instances of [`work.Unit`][unit-doc],
+like so:
 ```go
 uniter := work.NewSQLUniter(mappers, db)
 
@@ -144,7 +160,8 @@ if err != nil {
 
 ## Contribute
 
-Want to lend us a hand? Check out our guidelines for [contributing][contributing].
+Want to lend us a hand? Check out our guidelines for
+[contributing][contributing].
 
 ## License
 
@@ -152,11 +169,13 @@ We are rocking an [Apache 2.0 license][apache-license] for this project.
 
 ## Code of Conduct
 
-Please check out our [code of conduct][code-of-conduct] to get up to speed how we do things.
+Please check out our [code of conduct][code-of-conduct] to get up to speed
+how we do things.
 
 ## Artwork
 
-Discovered via the interwebs, the artwork was created by Marcus Olsson and Jon Calhoun for [Gophercises][gophercises].
+Discovered via the interwebs, the artwork was created by Marcus Olsson and
+Jon Calhoun for [Gophercises][gophercises].
 
 [uow]: https://martinfowler.com/eaaCatalog/unitOfWork.html
 [sql-data-mapper-doc]: https://godoc.org/github.com/freerware/work#SQLDataMapper
@@ -168,6 +187,8 @@ Discovered via the interwebs, the artwork was created by Marcus Olsson and Jon C
 [logger-doc]: https://godoc.org/go.uber.org/zap#Logger
 [scope-doc]: https://godoc.org/github.com/uber-go/tally#Scope
 [uniter-doc]: https://godoc.org/github.com/freerware/work#Uniter
+[unit-logger-doc]: https://godoc.org/github.com/freerware/work#pkg-variables
+[unit-scope-doc]: https://godoc.org/github.com/freerware/work#pkg-variables
 [contributing]: https://github.com/freerware/work/blob/master/CONTRIBUTING.md
 [apache-license]: https://github.com/freerware/work/blob/master/LICENSE.txt
 [code-of-conduct]: https://github.com/freerware/work/blob/master/CODE_OF_CONDUCT.md


### PR DESCRIPTION
**Description**

Cleans up the `README.md` by fixing grammatical errors, incorrect syntax in examples, and enforcing consistency.

**Rationale**

The ultimate distraction when diving into a `README.md` is mistakes in language or syntax. It is critical to make the `README.md` as easy to consume as possible. 

**Suggested Version**

`v2.0.2`

**Example Usage**

N/A - no code changes.
