### PR TITLE
Introduce work unit actions.

### DIFF
--- a/v3/unit_action.go
+++ b/v3/unit_action.go
@@ -1,0 +1,62 @@
+/* Copyright 2019 Freerware
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package work
+
+// Action represents an operation performed during a paticular lifecycle event of a work unit.
+type UnitAction func(UnitActionContext)
+
+// UnitActionType represents the type of work unit action.
+type UnitActionType int
+
+// The various types of actions that are executed throughout the lifecycle of a work unit.
+const (
+	// UnitActionTypeAfterRegister indicates an action type that occurs after an entity is registered.
+	UnitActionTypeAfterRegister = iota
+	// UnitActionTypeAfterAdd indicates an action type that occurs after an entity is added.
+	UnitActionTypeAfterAdd
+	// UnitActionTypeAfterAlter indicates an action type that occurs after an entity is altered.
+	UnitActionTypeAfterAlter
+	// UnitActionTypeAfterRemove indicates an action type that occurs after an entity is removed.
+	UnitActionTypeAfterRemove
+	// UnitActionTypeAfterInserts indicates an action type that occurs after new entities are inserted in the data store.
+	UnitActionTypeAfterInserts
+	// UnitActionTypeAfterUpdates indicates an action type that occurs after existing entities are updated in the data store.
+	UnitActionTypeAfterUpdates
+	// UnitActionTypeAfterDeletes indicates an action type that occurs after existing entities are deleted in the data store.
+	UnitActionTypeAfterDeletes
+	// UnitActionTypeAfterRollback indicates an action type that occurs after rollback.
+	UnitActionTypeAfterRollback
+	// UnitActionTypeAfterSave indicates an action type that occurs after save.
+	UnitActionTypeAfterSave
+	// UnitActionTypeBeforeRegister indicates an action type that occurs before an entity is registered.
+	UnitActionTypeBeforeRegister
+	// UnitActionTypeBeforeAdd indicates an action type that occurs before an entity is added.
+	UnitActionTypeBeforeAdd
+	// UnitActionTypeBeforeAlter indicates an action type that occurs before an entity is altered.
+	UnitActionTypeBeforeAlter
+	// UnitActionTypeBeforeRemove indicates an action type that occurs before an entity is removed.
+	UnitActionTypeBeforeRemove
+	// UnitActionTypeBeforeInserts indicates an action type that occurs before new entities are inserted in the data store.
+	UnitActionTypeBeforeInserts
+	// UnitActionTypeBeforeUpdates indicates an action type that occurs before existing entities are updated in the data store.
+	UnitActionTypeBeforeUpdates
+	// UnitActionTypeBeforeDeletes indicates an action type that occurs before existing entities are deleted in the data store.
+	UnitActionTypeBeforeDeletes
+	// UnitActionTypeBeforeRollback indicates an action type that occurs before rollback.
+	UnitActionTypeBeforeRollback
+	// UnitActionTypeBeforeSave indicates an action type that occurs before save.
+	UnitActionTypeBeforeSave
+)

--- a/v3/unit_action_context.go
+++ b/v3/unit_action_context.go
@@ -1,0 +1,37 @@
+/* Copyright 2019 Freerware
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package work
+
+import (
+	"github.com/uber-go/tally"
+	"go.uber.org/zap"
+)
+
+// UnitActionContext represents the executional context for an action.
+type UnitActionContext struct {
+	// Logger is the work units configured logger.
+	Logger *zap.Logger
+	// Scope is the work units configured metrics scope.
+	Scope tally.Scope
+	// AdditionCount represents the number of entities indicated as new.
+	AdditionCount int
+	// AlterationCount represents the number of entities indicated as modified.
+	AlterationCount int
+	// RemovalCount represents the number of entities indicated as removed.
+	RemovalCount int
+	// RegisterCount represents the number of entities indicated as registered.
+	RegisterCount int
+}

--- a/v3/unit_options.go
+++ b/v3/unit_options.go
@@ -1,3 +1,17 @@
+/* Copyright 2019 Freerware
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package work
 
 import (
@@ -8,8 +22,10 @@ import (
 // UnitOptions represents the configuration options
 // for the work unit.
 type UnitOptions struct {
-	Logger *zap.Logger
-	Scope  tally.Scope
+	Logger                       *zap.Logger
+	Scope                        tally.Scope
+	Actions                      map[UnitActionType][]UnitAction
+	DisableDefaultLoggingActions bool
 }
 
 // Option applies an option to the provided configuration.
@@ -27,6 +43,183 @@ var (
 	UnitScope = func(s tally.Scope) Option {
 		return func(o *UnitOptions) {
 			o.Scope = s
+		}
+	}
+
+	// setActions appends the provided actions as the provided action type.
+	setActions = func(t UnitActionType, a ...UnitAction) Option {
+		return func(o *UnitOptions) {
+			if o.Actions == nil {
+				o.Actions = make(map[UnitActionType][]UnitAction)
+			}
+			o.Actions[t] = append(o.Actions[t], a...)
+		}
+	}
+
+	// UnitAfterRegisterActions specifies the option to provide actions to execute
+	// after entities are registered with the work unit.
+	UnitAfterRegisterActions = func(a ...UnitAction) Option {
+		return setActions(UnitActionTypeAfterRegister, a...)
+	}
+
+	// UnitAfterAddActions specifies the option to provide actions to execute
+	// after entities are added with the work unit.
+	UnitAfterAddActions = func(a ...UnitAction) Option {
+		return setActions(UnitActionTypeAfterAdd, a...)
+	}
+
+	// UnitAfterAlterActions specifies the option to provide actions to execute
+	// after entities are altered with the work unit.
+	UnitAfterAlterActions = func(a ...UnitAction) Option {
+		return setActions(UnitActionTypeAfterAlter, a...)
+	}
+
+	// UnitAfterRemoveActions specifies the option to provide actions to execute
+	// after entities are removed with the work unit.
+	UnitAfterRemoveActions = func(a ...UnitAction) Option {
+		return setActions(UnitActionTypeAfterRemove, a...)
+	}
+
+	// UnitAfterInsertsActions specifies the option to provide actions to execute
+	// after new entities are inserted in the data store.
+	UnitAfterInsertsActions = func(a ...UnitAction) Option {
+		return setActions(UnitActionTypeAfterInserts, a...)
+	}
+
+	// UnitAfterUpdatesActions specifies the option to provide actions to execute
+	// after altered entities are updated in the data store.
+	UnitAfterUpdatesActions = func(a ...UnitAction) Option {
+		return setActions(UnitActionTypeAfterUpdates, a...)
+	}
+
+	// UnitAfterDeletesActions specifies the option to provide actions to execute
+	// after removed entities are deleted in the data store.
+	UnitAfterDeletesActions = func(a ...UnitAction) Option {
+		return setActions(UnitActionTypeAfterDeletes, a...)
+	}
+
+	// UnitAfterRollbackActions specifies the option to provide actions to execute
+	// after a rollback is performed.
+	UnitAfterRollbackActions = func(a ...UnitAction) Option {
+		return setActions(UnitActionTypeAfterRollback, a...)
+	}
+
+	// UnitAfterSaveActions specifies the option to provide actions to execute
+	// after a save is performed.
+	UnitAfterSaveActions = func(a ...UnitAction) Option {
+		return setActions(UnitActionTypeAfterSave, a...)
+	}
+
+	// UnitBeforeInsertsActions specifies the option to provide actions to execute
+	// before new entities are inserted in the data store.
+	UnitBeforeInsertsActions = func(a ...UnitAction) Option {
+		return setActions(UnitActionTypeBeforeInserts, a...)
+	}
+
+	// UnitBeforeUpdatesActions specifies the option to provide actions to execute
+	// before altered entities are updated in the data store.
+	UnitBeforeUpdatesActions = func(a ...UnitAction) Option {
+		return setActions(UnitActionTypeBeforeUpdates, a...)
+	}
+
+	// UnitBeforeDeletesActions specifies the option to provide actions to execute
+	// before removed entities are deleted in the data store.
+	UnitBeforeDeletesActions = func(a ...UnitAction) Option {
+		return setActions(UnitActionTypeBeforeDeletes, a...)
+	}
+
+	// UnitBeforeRollbackActions specifies the option to provide actions to execute
+	// before a rollback is performed.
+	UnitBeforeRollbackActions = func(a ...UnitAction) Option {
+		return setActions(UnitActionTypeBeforeRollback, a...)
+	}
+
+	// UnitBeforeSaveActions specifies the option to provide actions to execute
+	// before a save is performed.
+	UnitBeforeSaveActions = func(a ...UnitAction) Option {
+		return setActions(UnitActionTypeBeforeSave, a...)
+	}
+
+	// UnitDefaultLoggingActions specifies all of the default logging actions.
+	UnitDefaultLoggingActions = func() Option {
+		beforeInsertLogAction := func(ctx UnitActionContext) {
+			ctx.Logger.Debug(
+				"attempting to insert entities",
+				zap.Int("count", ctx.AdditionCount),
+			)
+		}
+		afterInsertLogAction := func(ctx UnitActionContext) {
+			ctx.Logger.Debug(
+				"successfully inserted entities",
+				zap.Int("count", ctx.AdditionCount),
+			)
+		}
+		beforeUpdateLogAction := func(ctx UnitActionContext) {
+			ctx.Logger.Debug(
+				"attempting to update entities",
+				zap.Int("count", ctx.AlterationCount),
+			)
+		}
+		afterUpdateLogAction := func(ctx UnitActionContext) {
+			ctx.Logger.Debug(
+				"successfully updated entities",
+				zap.Int("count", ctx.AlterationCount),
+			)
+		}
+		beforeDeleteLogAction := func(ctx UnitActionContext) {
+			ctx.Logger.Debug(
+				"attempting to delete entities",
+				zap.Int("count", ctx.RemovalCount),
+			)
+		}
+		afterDeleteLogAction := func(ctx UnitActionContext) {
+			ctx.Logger.Debug(
+				"successfully deleted entities",
+				zap.Int("count", ctx.RemovalCount),
+			)
+		}
+		beforeSaveLogAction := func(ctx UnitActionContext) {
+			ctx.Logger.Debug("attempting to save unit")
+		}
+		afterSaveLogAction := func(ctx UnitActionContext) {
+			totalCount :=
+				ctx.AdditionCount + ctx.AlterationCount + ctx.RemovalCount
+			ctx.Logger.Info("successfully saved unit",
+				zap.Int("insertCount", ctx.AdditionCount),
+				zap.Int("updateCount", ctx.AlterationCount),
+				zap.Int("deleteCount", ctx.RemovalCount),
+				zap.Int("registerCount", ctx.RegisterCount),
+				zap.Int("totalUpdateCount", totalCount))
+		}
+		beforeRollbackLogAction := func(ctx UnitActionContext) {
+			ctx.Logger.Debug("attempting to roll back unit")
+		}
+		afterRollbackLogAction := func(ctx UnitActionContext) {
+			ctx.Logger.Info("successfully rolled back unit")
+		}
+		return func(o *UnitOptions) {
+			subOpts := []Option{
+				setActions(UnitActionTypeBeforeInserts, beforeInsertLogAction),
+				setActions(UnitActionTypeAfterInserts, afterInsertLogAction),
+				setActions(UnitActionTypeBeforeUpdates, beforeUpdateLogAction),
+				setActions(UnitActionTypeAfterUpdates, afterUpdateLogAction),
+				setActions(UnitActionTypeBeforeDeletes, beforeDeleteLogAction),
+				setActions(UnitActionTypeAfterDeletes, afterDeleteLogAction),
+				setActions(UnitActionTypeBeforeSave, beforeSaveLogAction),
+				setActions(UnitActionTypeAfterSave, afterSaveLogAction),
+				setActions(UnitActionTypeBeforeRollback, beforeRollbackLogAction),
+				setActions(UnitActionTypeAfterRollback, afterRollbackLogAction),
+			}
+			for _, opt := range subOpts {
+				opt(o)
+			}
+		}
+	}
+
+	// DisableDefaultLoggingActions disables the default logging actions.
+	DisableDefaultLoggingActions = func() Option {
+		return func(o *UnitOptions) {
+			o.DisableDefaultLoggingActions = true
 		}
 	}
 )


### PR DESCRIPTION
**Description**

Introduces work unit actions ( as described in #27 ).

**Rationale**

Especially in larger, more complex codebases, it is likely desirable for consumers of `work` to specify particular actions (AKA “hooks”) before and after particular events occur. Common examples may be custom logging, observability/metrics, [opentracing](https://opentracing.io/) etc. In addition, actions make the package more extensible by giving the power of executing code during significant work unit lifecycle events.

**Suggested Version**

`v3.0.1`

**Example Usage**

```go
...

opts := []work.UnitOption {
  work.UnitLogger(l),
  work.UnitAfterRegister(func(ctx work.UnitContext) {
    ctx.Logger.Debug("🐛")
  }),
}

unit, err := work.NewSQLUnit(mappers, db, opts...)
if err != nil {
	panic(err)
}

...
```

**Discussion Points**

- Should `after*` actions execute when errors occur during the lifecycle event? For example, would all `afterInserts` actions be executed if an error occurs during insertion?
  - If not, does it limit the use cases for actions?
  - If so, does the error get passed to the actions?
- It's pretty obvious that general purpose logging should be implemented as actions, but what about metrics?

**Conclusions**

- We will only execute `after*` actions if the lifecycle event they are attached to succeeds.
  - Majority of the known use cases for actions are related to executing logic based on a successful lifecycle event.
  - In situations where an action would only want to execute on success, consuming code would have to ensure the action wasn't executed during failure, and would need support from the library to determine whether a failure occurred.
  - During failure situations, certain lifecycle events can be completely short-circuited. For example, if a failure occurs during lifecycle event where all new entities in the work unit are being inserted, the lifecycle events related to entity updates and deletions is never reached. Execution of those actions doesn't make sense.
- Since actions are only executed upon success of particular unit lifecycle milestones, we have chosen not to utilize actions as the means of encapsulating various metrics-related operations.
  - This is primarily due to the fact that we capture failure metrics, such as rollback failures, that currently (by design) cannot be captured using actions.