### PR TITLE
Update file headers.

### DIFF
--- a/best_effort_unit.go
+++ b/best_effort_unit.go
@@ -1,4 +1,4 @@
-/* Copyright 2019 Freerware
+/* Copyright 2020 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/best_effort_unit_test.go
+++ b/best_effort_unit_test.go
@@ -1,3 +1,18 @@
+/* Copyright 2020 Freerware
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package work_test
 
 import (

--- a/best_effort_uniter.go
+++ b/best_effort_uniter.go
@@ -1,4 +1,4 @@
-/* Copyright 2019 Freerware
+/* Copyright 2020 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/best_effort_uniter_test.go
+++ b/best_effort_uniter_test.go
@@ -1,3 +1,18 @@
+/* Copyright 2020 Freerware
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package work_test
 
 import (

--- a/data_mapper.go
+++ b/data_mapper.go
@@ -1,4 +1,4 @@
-/* Copyright 2019 Freerware
+/* Copyright 2020 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql_data_mapper.go
+++ b/sql_data_mapper.go
@@ -1,4 +1,4 @@
-/* Copyright 2019 Freerware
+/* Copyright 2020 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql_unit.go
+++ b/sql_unit.go
@@ -1,4 +1,4 @@
-/* Copyright 2019 Freerware
+/* Copyright 2020 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql_unit_test.go
+++ b/sql_unit_test.go
@@ -1,3 +1,18 @@
+/* Copyright 2020 Freerware
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package work_test
 
 import (

--- a/sql_uniter.go
+++ b/sql_uniter.go
@@ -1,4 +1,4 @@
-/* Copyright 2019 Freerware
+/* Copyright 2020 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql_uniter_test.go
+++ b/sql_uniter_test.go
@@ -1,3 +1,18 @@
+/* Copyright 2020 Freerware
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package work_test
 
 import (

--- a/type_name.go
+++ b/type_name.go
@@ -1,4 +1,4 @@
-/* Copyright 2019 Freerware
+/* Copyright 2020 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/unit.go
+++ b/unit.go
@@ -1,4 +1,4 @@
-/* Copyright 2019 Freerware
+/* Copyright 2020 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/uniter.go
+++ b/uniter.go
@@ -1,4 +1,4 @@
-/* Copyright 2019 Freerware
+/* Copyright 2020 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/best_effort_unit.go
+++ b/v3/best_effort_unit.go
@@ -1,4 +1,4 @@
-/* Copyright 2019 Freerware
+/* Copyright 2020 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/best_effort_unit_test.go
+++ b/v3/best_effort_unit_test.go
@@ -1,3 +1,18 @@
+/* Copyright 2020 Freerware
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package work_test
 
 import (

--- a/v3/best_effort_uniter.go
+++ b/v3/best_effort_uniter.go
@@ -1,4 +1,4 @@
-/* Copyright 2019 Freerware
+/* Copyright 2020 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/best_effort_uniter_test.go
+++ b/v3/best_effort_uniter_test.go
@@ -1,3 +1,18 @@
+/* Copyright 2020 Freerware
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package work_test
 
 import (

--- a/v3/data_mapper.go
+++ b/v3/data_mapper.go
@@ -1,4 +1,4 @@
-/* Copyright 2019 Freerware
+/* Copyright 2020 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/sql_data_mapper.go
+++ b/v3/sql_data_mapper.go
@@ -1,4 +1,4 @@
-/* Copyright 2019 Freerware
+/* Copyright 2020 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/sql_unit.go
+++ b/v3/sql_unit.go
@@ -1,4 +1,4 @@
-/* Copyright 2019 Freerware
+/* Copyright 2020 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/sql_unit_test.go
+++ b/v3/sql_unit_test.go
@@ -1,3 +1,18 @@
+/* Copyright 2020 Freerware
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package work_test
 
 import (

--- a/v3/sql_uniter.go
+++ b/v3/sql_uniter.go
@@ -1,4 +1,4 @@
-/* Copyright 2019 Freerware
+/* Copyright 2020 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/sql_uniter_test.go
+++ b/v3/sql_uniter_test.go
@@ -1,3 +1,18 @@
+/* Copyright 2020 Freerware
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package work_test
 
 import (

--- a/v3/type_name.go
+++ b/v3/type_name.go
@@ -1,4 +1,4 @@
-/* Copyright 2019 Freerware
+/* Copyright 2020 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/unit.go
+++ b/v3/unit.go
@@ -1,4 +1,4 @@
-/* Copyright 2019 Freerware
+/* Copyright 2020 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/unit_action.go
+++ b/v3/unit_action.go
@@ -1,4 +1,4 @@
-/* Copyright 2019 Freerware
+/* Copyright 2020 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/unit_action_context.go
+++ b/v3/unit_action_context.go
@@ -1,4 +1,4 @@
-/* Copyright 2019 Freerware
+/* Copyright 2020 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/unit_options.go
+++ b/v3/unit_options.go
@@ -1,4 +1,4 @@
-/* Copyright 2019 Freerware
+/* Copyright 2020 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/uniter.go
+++ b/v3/uniter.go
@@ -1,4 +1,4 @@
-/* Copyright 2019 Freerware
+/* Copyright 2020 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/work_test.go
+++ b/v3/work_test.go
@@ -1,3 +1,18 @@
+/* Copyright 2020 Freerware
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package work_test
 
 type Foo struct {

--- a/work_test.go
+++ b/work_test.go
@@ -1,3 +1,18 @@
+/* Copyright 2020 Freerware
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package work_test
 
 type Foo struct {


### PR DESCRIPTION
**Description**

Introduces file headers for test files. Updates the existing file headers to use the current year, as described in #33 .

**Rationale**

All files are subject to the license in place, so the file header should be present in all files. The current year should be utilized to emphasize relevancy of the license information.

**Suggested Version**

No need to bump the version for this change, as it's purely cosmetic.

**Example Usage**

No API changes or behavior changes were made, so this is not applicable.
