### PR TITLE
Modify 'Add', 'Alter', 'Remove', and 'Register' to support concurrency.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ bins:
 test: bins
 	@echo testing...
 	@#v1
-	@GO111MODULE=on go test -v -covermode=count -coverprofile=coverage.out github.com/freerware/work
+	@GO111MODULE=on go test -v -race -covermode=atomic -coverprofile=coverage.out github.com/freerware/work
 	@#v3
-	@cd ./v3 && GO111MODULE=on go test -v -covermode=count -coverprofile=coverage.out github.com/freerware/work/v3 && cd ..
+	@cd ./v3 && GO111MODULE=on go test -v -race -covermode=atomic -coverprofile=coverage.out github.com/freerware/work/v3 && cd ..
 	@echo done!
 
 mocks:

--- a/v3/best_effort_unit.go
+++ b/v3/best_effort_unit.go
@@ -217,7 +217,9 @@ func (u *bestEffortUnit) applyDeletes() (err error) {
 // Register tracks the provided entities as clean.
 func (u *bestEffortUnit) Register(entities ...interface{}) error {
 	c := func(t TypeName) bool {
+		u.mutex.RLock()
 		_, ok := u.mappers[t]
+		u.mutex.RUnlock()
 		return ok
 	}
 	return u.register(c, entities...)
@@ -226,7 +228,9 @@ func (u *bestEffortUnit) Register(entities ...interface{}) error {
 // Add marks the provided entities as new additions.
 func (u *bestEffortUnit) Add(entities ...interface{}) error {
 	c := func(t TypeName) bool {
+		u.mutex.RLock()
 		_, ok := u.mappers[t]
+		u.mutex.RUnlock()
 		return ok
 	}
 	return u.add(c, entities...)
@@ -235,7 +239,9 @@ func (u *bestEffortUnit) Add(entities ...interface{}) error {
 // Alter marks the provided entities as modifications.
 func (u *bestEffortUnit) Alter(entities ...interface{}) error {
 	c := func(t TypeName) bool {
+		u.mutex.RLock()
 		_, ok := u.mappers[t]
+		u.mutex.RUnlock()
 		return ok
 	}
 	return u.alter(c, entities...)
@@ -244,7 +250,9 @@ func (u *bestEffortUnit) Alter(entities ...interface{}) error {
 // Remove marks the provided entities as removals.
 func (u *bestEffortUnit) Remove(entities ...interface{}) error {
 	c := func(t TypeName) bool {
+		u.mutex.RLock()
 		_, ok := u.mappers[t]
+		u.mutex.RUnlock()
 		return ok
 	}
 	return u.remove(c, entities...)

--- a/v3/best_effort_unit_test.go
+++ b/v3/best_effort_unit_test.go
@@ -18,6 +18,7 @@ package work_test
 import (
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/freerware/work/v3"
@@ -686,6 +687,31 @@ func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Add() {
 	s.NoError(err)
 }
 
+func (s *BestEffortUnitTestSuite) TestBestEffortUnit_ConcurrentAdd() {
+
+	// arrange.
+	foo := Foo{ID: 28}
+	bar := Bar{ID: "28"}
+
+	// action.
+	var err, err2 error
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		err = s.sut.Add(foo)
+		wg.Done()
+	}()
+	go func() {
+		err2 = s.sut.Add(bar)
+		wg.Done()
+	}()
+	wg.Wait()
+
+	// assert.
+	s.NoError(err)
+	s.NoError(err2)
+}
+
 func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Alter_Empty() {
 
 	// arrange.
@@ -731,6 +757,31 @@ func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Alter() {
 
 	// assert.
 	s.NoError(err)
+}
+
+func (s *BestEffortUnitTestSuite) TestBestEffortUnit_ConcurrentAlter() {
+
+	// arrange.
+	foo := Foo{ID: 28}
+	bar := Bar{ID: "28"}
+
+	// action.
+	var err, err2 error
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		err = s.sut.Alter(foo)
+		wg.Done()
+	}()
+	go func() {
+		err2 = s.sut.Alter(bar)
+		wg.Done()
+	}()
+	wg.Wait()
+
+	// assert.
+	s.NoError(err)
+	s.NoError(err2)
 }
 
 func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Remove_Empty() {
@@ -780,6 +831,31 @@ func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Remove() {
 	s.NoError(err)
 }
 
+func (s *BestEffortUnitTestSuite) TestBestEffortUnit_ConcurrentRemove() {
+
+	// arrange.
+	foo := Foo{ID: 28}
+	bar := Bar{ID: "28"}
+
+	// action.
+	var err, err2 error
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		err = s.sut.Remove(foo)
+		wg.Done()
+	}()
+	go func() {
+		err2 = s.sut.Remove(bar)
+		wg.Done()
+	}()
+	wg.Wait()
+
+	// assert.
+	s.NoError(err)
+	s.NoError(err2)
+}
+
 func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Register_Empty() {
 
 	// arrange.
@@ -826,6 +902,31 @@ func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Register() {
 
 	// assert.
 	s.NoError(err)
+}
+
+func (s *BestEffortUnitTestSuite) TestBestEffortUnit_ConcurrentRegister() {
+
+	// arrange.
+	foo := Foo{ID: 28}
+	bar := Bar{ID: "28"}
+
+	// action.
+	var err, err2 error
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		err = s.sut.Register(foo)
+		wg.Done()
+	}()
+	go func() {
+		err2 = s.sut.Register(bar)
+		wg.Done()
+	}()
+	wg.Wait()
+
+	// assert.
+	s.NoError(err)
+	s.NoError(err2)
 }
 
 func (s *BestEffortUnitTestSuite) TearDownTest() {

--- a/v3/sql_unit.go
+++ b/v3/sql_unit.go
@@ -72,7 +72,9 @@ func NewSQLUnit(
 // Register tracks the provided entities as clean.
 func (u *sqlUnit) Register(entities ...interface{}) error {
 	c := func(t TypeName) bool {
+		u.mutex.RLock()
 		_, ok := u.mappers[t]
+		u.mutex.RUnlock()
 		return ok
 	}
 	return u.register(c, entities...)
@@ -81,7 +83,9 @@ func (u *sqlUnit) Register(entities ...interface{}) error {
 // Add marks the provided entities as new additions.
 func (u *sqlUnit) Add(entities ...interface{}) error {
 	c := func(t TypeName) bool {
+		u.mutex.RLock()
 		_, ok := u.mappers[t]
+		u.mutex.RUnlock()
 		return ok
 	}
 	return u.add(c, entities...)
@@ -90,7 +94,9 @@ func (u *sqlUnit) Add(entities ...interface{}) error {
 // Alter marks the provided entities as modifications.
 func (u *sqlUnit) Alter(entities ...interface{}) error {
 	c := func(t TypeName) bool {
+		u.mutex.RLock()
 		_, ok := u.mappers[t]
+		u.mutex.RUnlock()
 		return ok
 	}
 	return u.alter(c, entities...)
@@ -99,7 +105,9 @@ func (u *sqlUnit) Alter(entities ...interface{}) error {
 // Remove marks the provided entities as removals.
 func (u *sqlUnit) Remove(entities ...interface{}) error {
 	c := func(t TypeName) bool {
+		u.mutex.RLock()
 		_, ok := u.mappers[t]
+		u.mutex.RUnlock()
 		return ok
 	}
 	return u.remove(c, entities...)

--- a/v3/sql_unit_test.go
+++ b/v3/sql_unit_test.go
@@ -19,6 +19,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -653,6 +654,31 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Add() {
 	s.NoError(err)
 }
 
+func (s *SQLUnitTestSuite) TestSQLUnit_ConcurrentAdd() {
+
+	// arrange.
+	foo := Foo{ID: 28}
+	bar := Bar{ID: "28"}
+
+	// action.
+	var err, err2 error
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		err = s.sut.Add(foo)
+		wg.Done()
+	}()
+	go func() {
+		err2 = s.sut.Add(bar)
+		wg.Done()
+	}()
+	wg.Wait()
+
+	// assert.
+	s.NoError(err)
+	s.NoError(err2)
+}
+
 func (s *SQLUnitTestSuite) TestSQLUnit_Alter_Empty() {
 
 	// arrange.
@@ -698,6 +724,31 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Alter() {
 
 	// assert.
 	s.NoError(err)
+}
+
+func (s *SQLUnitTestSuite) TestSQLUnit_ConcurrentAlter() {
+
+	// arrange.
+	foo := Foo{ID: 28}
+	bar := Bar{ID: "28"}
+
+	// action.
+	var err, err2 error
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		err = s.sut.Alter(foo)
+		wg.Done()
+	}()
+	go func() {
+		err2 = s.sut.Alter(bar)
+		wg.Done()
+	}()
+	wg.Wait()
+
+	// assert.
+	s.NoError(err)
+	s.NoError(err2)
 }
 
 func (s *SQLUnitTestSuite) TestSQLUnit_Remove_Empty() {
@@ -747,6 +798,31 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Remove() {
 	s.NoError(err)
 }
 
+func (s *SQLUnitTestSuite) TestSQLUnit_ConcurrentRemove() {
+
+	// arrange.
+	foo := Foo{ID: 28}
+	bar := Bar{ID: "28"}
+
+	// action.
+	var err, err2 error
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		err = s.sut.Remove(foo)
+		wg.Done()
+	}()
+	go func() {
+		err2 = s.sut.Remove(bar)
+		wg.Done()
+	}()
+	wg.Wait()
+
+	// assert.
+	s.NoError(err)
+	s.NoError(err2)
+}
+
 func (s *SQLUnitTestSuite) TestSQLUnit_Register_Empty() {
 
 	// arrange.
@@ -793,6 +869,31 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Register() {
 
 	// assert.
 	s.NoError(err)
+}
+
+func (s *SQLUnitTestSuite) TestSQLUnit_ConcurrentRegister() {
+
+	// arrange.
+	foo := Foo{ID: 28}
+	bar := Bar{ID: "28"}
+
+	// action.
+	var err, err2 error
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		err = s.sut.Register(foo)
+		wg.Done()
+	}()
+	go func() {
+		err2 = s.sut.Register(bar)
+		wg.Done()
+	}()
+	wg.Wait()
+
+	// assert.
+	s.NoError(err)
+	s.NoError(err2)
 }
 
 func (s *SQLUnitTestSuite) TearDownTest() {


### PR DESCRIPTION
**Description**

Adapt `Add`, `Alter`, `Remove`, and `Register` methods to support concurrency. In addition, modify `Makefile` to run `go test` with the [`-race`](https://blog.golang.org/race-detector) flag to detect race conditions. Ensure we utilize `-covermode=atomic` as described in the [Golang blog](https://blog.golang.org/cover).

**Rationale**

Performant programs need to leverage concurrency to take on multiple operations. Of such situations, often times those operations are related to logic that ultimately will determine new data needs to be created, existing data needs to be modified or removed, or registering data as it was reconstituted. As a result, work units need to support concurrent usage of the `Add`, `Alter`, `Remove`, and `Register` operations.

**Suggested Version**

`v3.2.0`

**Example Usage**

There are no API changes or behavioral changes - nothing to demonstrate here!
