### PR TITLE
Introduce retry functionality.

### DIFF
--- a/v4/best_effort_unit_test.go
+++ b/v4/best_effort_unit_test.go
@@ -57,6 +57,8 @@ type BestEffortUnitTestSuite struct {
 	// suite state.
 	isSetup    bool
 	isTornDown bool
+
+	retryCount int
 }
 
 func TestBestEffortUnitTestSuite(t *testing.T) {
@@ -103,12 +105,14 @@ func (s *BestEffortUnitTestSuite) Setup() {
 	c.DisableStacktrace = true
 	l, _ := c.Build()
 	ts := tally.NewTestScope(s.scopePrefix, map[string]string{})
+	s.retryCount = 2
 	s.scope = ts
 	var err error
 	opts := []work.UnitOption{
 		work.UnitDataMappers(dm),
 		work.UnitLogger(l),
 		work.UnitScope(ts),
+		work.UnitRetryAttempts(s.retryCount),
 	}
 	s.sut, err = work.NewUnit(opts...)
 	s.Require().NoError(err)

--- a/v4/go.mod
+++ b/v4/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.3.3
+	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/golang/mock v1.4.4
 	github.com/stretchr/testify v1.4.0
 	github.com/uber-go/tally v3.3.13+incompatible

--- a/v4/go.sum
+++ b/v4/go.sum
@@ -2,6 +2,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFDnH08=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
+github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/v4/sql_unit.go
+++ b/v4/sql_unit.go
@@ -116,8 +116,6 @@ func (u *sqlUnit) applyDeletes(ctx context.Context, mCtx MapperContext) (err err
 }
 
 func (u *sqlUnit) save(ctx context.Context) (err error) {
-	u.retryOptions = append(u.retryOptions, retry.Context(ctx))
-
 	//start transaction.
 	tx, err := u.db.BeginTx(ctx, nil)
 	mCtx := MapperContext{Tx: tx}
@@ -194,6 +192,7 @@ func (u *sqlUnit) Save(ctx context.Context) (err error) {
 		}
 	}()
 
+	u.retryOptions = append(u.retryOptions, retry.Context(ctx))
 	err = retry.Do(func() error { return u.save(ctx) }, u.retryOptions...)
 	return
 }

--- a/v4/sql_unit.go
+++ b/v4/sql_unit.go
@@ -185,6 +185,9 @@ func (u *sqlUnit) Save(ctx context.Context) (err error) {
 	stop := u.scope.Timer(save).Start().Stop
 	defer func() {
 		stop()
+		if r := recover(); r != nil {
+			panic(r)
+		}
 		if err == nil {
 			u.scope.Counter(saveSuccess).Inc(1)
 			u.executeActions(UnitActionTypeAfterSave)

--- a/v4/sql_unit_test.go
+++ b/v4/sql_unit_test.go
@@ -143,7 +143,9 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 			alters:    []interface{}{foos[1], bars[1]},
 			removals:  []interface{}{foos[2]},
 			expectations: func(ctx context.Context, registers, additions, alters, removals []interface{}) {
-				s._db.ExpectBegin().WillReturnError(errors.New("whoa"))
+				for i := 0; i < s.retryCount; i++ {
+					s._db.ExpectBegin().WillReturnError(errors.New("whoa"))
+				}
 			},
 			ctx:        context.Background(),
 			err:        errors.New("whoa"),
@@ -155,7 +157,9 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 			alters:    []interface{}{foos[1], bars[1]},
 			removals:  []interface{}{foos[2]},
 			expectations: func(ctx context.Context, registers, additions, alters, removals []interface{}) {
-				s._db.ExpectBegin().WillReturnError(errors.New("whoa"))
+				for i := 0; i < s.retryCount; i++ {
+					s._db.ExpectBegin().WillReturnError(errors.New("whoa"))
+				}
 			},
 			ctx: context.Background(),
 			err: errors.New("whoa"),
@@ -172,8 +176,10 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 			alters:    []interface{}{foos[1], bars[1]},
 			removals:  []interface{}{foos[2]},
 			expectations: func(ctx context.Context, registers, additions, alters, removals []interface{}) {
-				s._db.ExpectBegin()
-				s._db.ExpectRollback()
+				for i := 0; i < s.retryCount; i++ {
+					s._db.ExpectBegin()
+					s._db.ExpectRollback()
+				}
 				s.mappers[fooType].EXPECT().Insert(ctx, gomock.Any(), additions[0]).Return(errors.New("whoa")).Times(s.retryCount)
 			},
 			ctx:        context.Background(),
@@ -186,8 +192,10 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 			alters:    []interface{}{foos[1], bars[1]},
 			removals:  []interface{}{foos[2]},
 			expectations: func(ctx context.Context, registers, additions, alters, removals []interface{}) {
-				s._db.ExpectBegin()
-				s._db.ExpectRollback()
+				for i := 0; i < s.retryCount; i++ {
+					s._db.ExpectBegin()
+					s._db.ExpectRollback()
+				}
 				s.mappers[fooType].EXPECT().Insert(ctx, gomock.Any(), additions[0]).Return(errors.New("whoa")).Times(s.retryCount)
 			},
 			ctx: context.Background(),
@@ -206,8 +214,10 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 			alters:    []interface{}{foos[1], bars[1]},
 			removals:  []interface{}{foos[2]},
 			expectations: func(ctx context.Context, registers, additions, alters, removals []interface{}) {
-				s._db.ExpectBegin()
-				s._db.ExpectRollback().WillReturnError(errors.New("whoa"))
+				for i := 0; i < s.retryCount; i++ {
+					s._db.ExpectBegin()
+					s._db.ExpectRollback().WillReturnError(errors.New("whoa"))
+				}
 				s.mappers[fooType].EXPECT().Insert(ctx, gomock.Any(), additions[0]).Return(errors.New("ouch")).Times(s.retryCount)
 			},
 			ctx:        context.Background(),
@@ -220,8 +230,10 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 			alters:    []interface{}{foos[1], bars[1]},
 			removals:  []interface{}{foos[2]},
 			expectations: func(ctx context.Context, registers, additions, alters, removals []interface{}) {
-				s._db.ExpectBegin()
-				s._db.ExpectRollback().WillReturnError(errors.New("whoa"))
+				for i := 0; i < s.retryCount; i++ {
+					s._db.ExpectBegin()
+					s._db.ExpectRollback().WillReturnError(errors.New("whoa"))
+				}
 				s.mappers[fooType].EXPECT().Insert(ctx, gomock.Any(), additions[0]).Return(errors.New("ouch")).Times(s.retryCount)
 			},
 			ctx: context.Background(),
@@ -240,10 +252,12 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 			alters:    []interface{}{foos[1]},
 			removals:  []interface{}{foos[2]},
 			expectations: func(ctx context.Context, registers, additions, alters, removals []interface{}) {
-				s._db.ExpectBegin()
-				s._db.ExpectRollback()
-				s.mappers[fooType].EXPECT().Insert(ctx, gomock.Any(), additions[0]).Return(nil)
-				s.mappers[barType].EXPECT().Insert(ctx, gomock.Any(), additions[1]).Return(nil)
+				for i := 0; i < s.retryCount; i++ {
+					s._db.ExpectBegin()
+					s._db.ExpectRollback()
+				}
+				s.mappers[fooType].EXPECT().Insert(ctx, gomock.Any(), additions[0]).Return(nil).Times(s.retryCount)
+				s.mappers[barType].EXPECT().Insert(ctx, gomock.Any(), additions[1]).Return(nil).Times(s.retryCount)
 				s.mappers[fooType].EXPECT().Update(ctx, gomock.Any(), alters[0]).Return(errors.New("whoa")).Times(s.retryCount)
 			},
 			ctx:        context.Background(),
@@ -256,10 +270,12 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 			alters:    []interface{}{foos[1]},
 			removals:  []interface{}{foos[2]},
 			expectations: func(ctx context.Context, registers, additions, alters, removals []interface{}) {
-				s._db.ExpectBegin()
-				s._db.ExpectRollback()
-				s.mappers[fooType].EXPECT().Insert(ctx, gomock.Any(), additions[0]).Return(nil)
-				s.mappers[barType].EXPECT().Insert(ctx, gomock.Any(), additions[1]).Return(nil)
+				for i := 0; i < s.retryCount; i++ {
+					s._db.ExpectBegin()
+					s._db.ExpectRollback()
+				}
+				s.mappers[fooType].EXPECT().Insert(ctx, gomock.Any(), additions[0]).Return(nil).Times(s.retryCount)
+				s.mappers[barType].EXPECT().Insert(ctx, gomock.Any(), additions[1]).Return(nil).Times(s.retryCount)
 				s.mappers[fooType].EXPECT().Update(ctx, gomock.Any(), alters[0]).Return(errors.New("whoa")).Times(s.retryCount)
 			},
 			ctx: context.Background(),
@@ -278,10 +294,12 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 			alters:    []interface{}{foos[1]},
 			removals:  []interface{}{foos[2]},
 			expectations: func(ctx context.Context, registers, additions, alters, removals []interface{}) {
-				s._db.ExpectBegin()
-				s._db.ExpectRollback().WillReturnError(errors.New("whoa"))
-				s.mappers[fooType].EXPECT().Insert(ctx, gomock.Any(), additions[0]).Return(nil)
-				s.mappers[barType].EXPECT().Insert(ctx, gomock.Any(), additions[1]).Return(nil)
+				for i := 0; i < s.retryCount; i++ {
+					s._db.ExpectBegin()
+					s._db.ExpectRollback().WillReturnError(errors.New("whoa"))
+				}
+				s.mappers[fooType].EXPECT().Insert(ctx, gomock.Any(), additions[0]).Return(nil).Times(s.retryCount)
+				s.mappers[barType].EXPECT().Insert(ctx, gomock.Any(), additions[1]).Return(nil).Times(s.retryCount)
 				s.mappers[fooType].EXPECT().Update(ctx, gomock.Any(), alters[0]).Return(errors.New("ouch")).Times(s.retryCount)
 			},
 			ctx:        context.Background(),
@@ -294,10 +312,12 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 			alters:    []interface{}{foos[1]},
 			removals:  []interface{}{foos[2]},
 			expectations: func(ctx context.Context, registers, additions, alters, removals []interface{}) {
-				s._db.ExpectBegin()
-				s._db.ExpectRollback().WillReturnError(errors.New("whoa"))
-				s.mappers[fooType].EXPECT().Insert(ctx, gomock.Any(), additions[0]).Return(nil)
-				s.mappers[barType].EXPECT().Insert(ctx, gomock.Any(), additions[1]).Return(nil)
+				for i := 0; i < s.retryCount; i++ {
+					s._db.ExpectBegin()
+					s._db.ExpectRollback().WillReturnError(errors.New("whoa"))
+				}
+				s.mappers[fooType].EXPECT().Insert(ctx, gomock.Any(), additions[0]).Return(nil).Times(s.retryCount)
+				s.mappers[barType].EXPECT().Insert(ctx, gomock.Any(), additions[1]).Return(nil).Times(s.retryCount)
 				s.mappers[fooType].EXPECT().Update(ctx, gomock.Any(), alters[0]).Return(errors.New("ouch")).Times(s.retryCount)
 			},
 			ctx: context.Background(),
@@ -316,12 +336,14 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 			alters:    []interface{}{foos[1], bars[1]},
 			removals:  []interface{}{foos[2]},
 			expectations: func(ctx context.Context, registers, additions, alters, removals []interface{}) {
-				s._db.ExpectBegin()
-				s._db.ExpectRollback()
-				s.mappers[fooType].EXPECT().Insert(ctx, gomock.Any(), additions[0]).Return(nil)
-				s.mappers[barType].EXPECT().Insert(ctx, gomock.Any(), additions[1]).Return(nil)
-				s.mappers[fooType].EXPECT().Update(ctx, gomock.Any(), alters[0]).Return(nil)
-				s.mappers[barType].EXPECT().Update(ctx, gomock.Any(), alters[1]).Return(nil)
+				for i := 0; i < s.retryCount; i++ {
+					s._db.ExpectBegin()
+					s._db.ExpectRollback()
+				}
+				s.mappers[fooType].EXPECT().Insert(ctx, gomock.Any(), additions[0]).Return(nil).Times(s.retryCount)
+				s.mappers[barType].EXPECT().Insert(ctx, gomock.Any(), additions[1]).Return(nil).Times(s.retryCount)
+				s.mappers[fooType].EXPECT().Update(ctx, gomock.Any(), alters[0]).Return(nil).Times(s.retryCount)
+				s.mappers[barType].EXPECT().Update(ctx, gomock.Any(), alters[1]).Return(nil).Times(s.retryCount)
 				s.mappers[fooType].EXPECT().Delete(ctx, gomock.Any(), removals[0]).Return(errors.New("whoa")).Times(s.retryCount)
 			},
 			ctx:        context.Background(),
@@ -334,12 +356,14 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 			alters:    []interface{}{foos[1], bars[1]},
 			removals:  []interface{}{foos[2]},
 			expectations: func(ctx context.Context, registers, additions, alters, removals []interface{}) {
-				s._db.ExpectBegin()
-				s._db.ExpectRollback()
-				s.mappers[fooType].EXPECT().Insert(ctx, gomock.Any(), additions[0]).Return(nil)
-				s.mappers[barType].EXPECT().Insert(ctx, gomock.Any(), additions[1]).Return(nil)
-				s.mappers[fooType].EXPECT().Update(ctx, gomock.Any(), alters[0]).Return(nil)
-				s.mappers[barType].EXPECT().Update(ctx, gomock.Any(), alters[1]).Return(nil)
+				for i := 0; i < s.retryCount; i++ {
+					s._db.ExpectBegin()
+					s._db.ExpectRollback()
+				}
+				s.mappers[fooType].EXPECT().Insert(ctx, gomock.Any(), additions[0]).Return(nil).Times(s.retryCount)
+				s.mappers[barType].EXPECT().Insert(ctx, gomock.Any(), additions[1]).Return(nil).Times(s.retryCount)
+				s.mappers[fooType].EXPECT().Update(ctx, gomock.Any(), alters[0]).Return(nil).Times(s.retryCount)
+				s.mappers[barType].EXPECT().Update(ctx, gomock.Any(), alters[1]).Return(nil).Times(s.retryCount)
 				s.mappers[fooType].EXPECT().Delete(ctx, gomock.Any(), removals[0]).Return(errors.New("whoa")).Times(s.retryCount)
 			},
 			ctx: context.Background(),
@@ -358,12 +382,14 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 			alters:    []interface{}{foos[1], bars[1]},
 			removals:  []interface{}{foos[2]},
 			expectations: func(ctx context.Context, registers, additions, alters, removals []interface{}) {
-				s._db.ExpectBegin()
-				s._db.ExpectRollback().WillReturnError(errors.New("whoa"))
-				s.mappers[fooType].EXPECT().Insert(ctx, gomock.Any(), additions[0]).Return(nil)
-				s.mappers[barType].EXPECT().Insert(ctx, gomock.Any(), additions[1]).Return(nil)
-				s.mappers[fooType].EXPECT().Update(ctx, gomock.Any(), alters[0]).Return(nil)
-				s.mappers[barType].EXPECT().Update(ctx, gomock.Any(), alters[1]).Return(nil)
+				for i := 0; i < s.retryCount; i++ {
+					s._db.ExpectBegin()
+					s._db.ExpectRollback().WillReturnError(errors.New("whoa"))
+				}
+				s.mappers[fooType].EXPECT().Insert(ctx, gomock.Any(), additions[0]).Return(nil).Times(s.retryCount)
+				s.mappers[barType].EXPECT().Insert(ctx, gomock.Any(), additions[1]).Return(nil).Times(s.retryCount)
+				s.mappers[fooType].EXPECT().Update(ctx, gomock.Any(), alters[0]).Return(nil).Times(s.retryCount)
+				s.mappers[barType].EXPECT().Update(ctx, gomock.Any(), alters[1]).Return(nil).Times(s.retryCount)
 				s.mappers[fooType].EXPECT().Delete(ctx, gomock.Any(), removals[0]).Return(errors.New("whoa")).Times(s.retryCount)
 			},
 			ctx:        context.Background(),
@@ -376,12 +402,14 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 			alters:    []interface{}{foos[1], bars[1]},
 			removals:  []interface{}{foos[2]},
 			expectations: func(ctx context.Context, registers, additions, alters, removals []interface{}) {
-				s._db.ExpectBegin()
-				s._db.ExpectRollback().WillReturnError(errors.New("whoa"))
-				s.mappers[fooType].EXPECT().Insert(ctx, gomock.Any(), additions[0]).Return(nil)
-				s.mappers[barType].EXPECT().Insert(ctx, gomock.Any(), additions[1]).Return(nil)
-				s.mappers[fooType].EXPECT().Update(ctx, gomock.Any(), alters[0]).Return(nil)
-				s.mappers[barType].EXPECT().Update(ctx, gomock.Any(), alters[1]).Return(nil)
+				for i := 0; i < s.retryCount; i++ {
+					s._db.ExpectBegin()
+					s._db.ExpectRollback().WillReturnError(errors.New("whoa"))
+				}
+				s.mappers[fooType].EXPECT().Insert(ctx, gomock.Any(), additions[0]).Return(nil).Times(s.retryCount)
+				s.mappers[barType].EXPECT().Insert(ctx, gomock.Any(), additions[1]).Return(nil).Times(s.retryCount)
+				s.mappers[fooType].EXPECT().Update(ctx, gomock.Any(), alters[0]).Return(nil).Times(s.retryCount)
+				s.mappers[barType].EXPECT().Update(ctx, gomock.Any(), alters[1]).Return(nil).Times(s.retryCount)
 				s.mappers[fooType].EXPECT().Delete(ctx, gomock.Any(), removals[0]).Return(errors.New("whoa")).Times(s.retryCount)
 			},
 			ctx: context.Background(),
@@ -484,13 +512,15 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 			alters:    []interface{}{foos[1], bars[1]},
 			removals:  []interface{}{foos[2]},
 			expectations: func(ctx context.Context, registers, additions, alters, removals []interface{}) {
-				s._db.ExpectBegin()
-				s._db.ExpectCommit().WillReturnError(errors.New("whoa"))
-				s.mappers[fooType].EXPECT().Insert(ctx, gomock.Any(), additions[0]).Return(nil)
-				s.mappers[barType].EXPECT().Insert(ctx, gomock.Any(), additions[1]).Return(nil)
-				s.mappers[fooType].EXPECT().Update(ctx, gomock.Any(), alters[0]).Return(nil)
-				s.mappers[barType].EXPECT().Update(ctx, gomock.Any(), alters[1]).Return(nil)
-				s.mappers[fooType].EXPECT().Delete(ctx, gomock.Any(), removals[0]).Return(nil)
+				for i := 0; i < s.retryCount; i++ {
+					s._db.ExpectBegin()
+					s._db.ExpectCommit().WillReturnError(errors.New("whoa"))
+				}
+				s.mappers[fooType].EXPECT().Insert(ctx, gomock.Any(), additions[0]).Return(nil).Times(s.retryCount)
+				s.mappers[barType].EXPECT().Insert(ctx, gomock.Any(), additions[1]).Return(nil).Times(s.retryCount)
+				s.mappers[fooType].EXPECT().Update(ctx, gomock.Any(), alters[0]).Return(nil).Times(s.retryCount)
+				s.mappers[barType].EXPECT().Update(ctx, gomock.Any(), alters[1]).Return(nil).Times(s.retryCount)
+				s.mappers[fooType].EXPECT().Delete(ctx, gomock.Any(), removals[0]).Return(nil).Times(s.retryCount)
 			},
 			ctx:        context.Background(),
 			err:        errors.New("whoa"),
@@ -502,13 +532,15 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 			alters:    []interface{}{foos[1], bars[1]},
 			removals:  []interface{}{foos[2]},
 			expectations: func(ctx context.Context, registers, additions, alters, removals []interface{}) {
-				s._db.ExpectBegin()
-				s._db.ExpectCommit().WillReturnError(errors.New("whoa"))
-				s.mappers[fooType].EXPECT().Insert(ctx, gomock.Any(), additions[0]).Return(nil)
-				s.mappers[barType].EXPECT().Insert(ctx, gomock.Any(), additions[1]).Return(nil)
-				s.mappers[fooType].EXPECT().Update(ctx, gomock.Any(), alters[0]).Return(nil)
-				s.mappers[barType].EXPECT().Update(ctx, gomock.Any(), alters[1]).Return(nil)
-				s.mappers[fooType].EXPECT().Delete(ctx, gomock.Any(), removals[0]).Return(nil)
+				for i := 0; i < s.retryCount; i++ {
+					s._db.ExpectBegin()
+					s._db.ExpectCommit().WillReturnError(errors.New("whoa"))
+				}
+				s.mappers[fooType].EXPECT().Insert(ctx, gomock.Any(), additions[0]).Return(nil).Times(s.retryCount)
+				s.mappers[barType].EXPECT().Insert(ctx, gomock.Any(), additions[1]).Return(nil).Times(s.retryCount)
+				s.mappers[fooType].EXPECT().Update(ctx, gomock.Any(), alters[0]).Return(nil).Times(s.retryCount)
+				s.mappers[barType].EXPECT().Update(ctx, gomock.Any(), alters[1]).Return(nil).Times(s.retryCount)
+				s.mappers[fooType].EXPECT().Delete(ctx, gomock.Any(), removals[0]).Return(nil).Times(s.retryCount)
 			},
 			ctx: context.Background(),
 			err: errors.New("whoa"),

--- a/v4/unit.go
+++ b/v4/unit.go
@@ -114,7 +114,7 @@ func NewUnit(opts ...UnitOption) (Unit, error) {
 		retry.LastErrorOnly(true),
 		retry.OnRetry(func(attempt uint, err error) {
 			options.Logger.Warn(
-				"attempting retry",
+				"attempted retry",
 				zap.Int("attempt", int(attempt+1)),
 				zap.Error(err),
 			)

--- a/v4/unit.go
+++ b/v4/unit.go
@@ -88,12 +88,13 @@ type unit struct {
 func options(options []UnitOption) UnitOptions {
 	// set defaults.
 	o := UnitOptions{
-		Logger:        zap.NewNop(),
-		Scope:         tally.NoopScope,
-		Actions:       make(map[UnitActionType][]UnitAction),
-		RetryAttempts: 3,
-		RetryType:     RetryTypeFixed,
-		RetryDelay:    50 * time.Millisecond,
+		Logger:             zap.NewNop(),
+		Scope:              tally.NoopScope,
+		Actions:            make(map[UnitActionType][]UnitAction),
+		RetryAttempts:      3,
+		RetryType:          RetryTypeFixed,
+		RetryDelay:         50 * time.Millisecond,
+		RetryMaximumJitter: 50 * time.Millisecond,
 	}
 	// apply options.
 	for _, opt := range options {

--- a/v4/unit/alias.go
+++ b/v4/unit/alias.go
@@ -115,6 +115,12 @@ var (
 	DefaultLoggingActions = work.UnitDefaultLoggingActions
 	// DisableDefaultLoggingActions disables the default logging actions.
 	DisableDefaultLoggingActions = work.DisableDefaultLoggingActions
+	// RetryAttempts defines the number of retry attempts to perform.
+	RetryAttempts = work.UnitRetryAttempts
+	// RetryDelay defines the delay to utilize during retries.
+	RetryDelay = work.UnitRetryDelay
+	// RetryType defines the type of retry to perform.
+	RetryType = work.UnitRetryType
 )
 
 /* Actions. */

--- a/v4/unit/alias.go
+++ b/v4/unit/alias.go
@@ -119,6 +119,9 @@ var (
 	RetryAttempts = work.UnitRetryAttempts
 	// RetryDelay defines the delay to utilize during retries.
 	RetryDelay = work.UnitRetryDelay
+	// RetryMaximumJitter defines the maximum jitter to utilize during
+	// retries that utilize random delay times.
+	RetryMaximumJitter = work.UnitRetryMaximumJitter
 	// RetryType defines the type of retry to perform.
 	RetryType = work.UnitRetryType
 )

--- a/v4/unit_options.go
+++ b/v4/unit_options.go
@@ -34,6 +34,7 @@ type UnitOptions struct {
 	DB                           *sql.DB
 	RetryAttempts                int
 	RetryDelay                   time.Duration
+	RetryMaximumJitter           time.Duration
 	RetryType                    RetryType
 }
 
@@ -287,6 +288,14 @@ var (
 	UnitRetryDelay = func(delay time.Duration) UnitOption {
 		return func(o *UnitOptions) {
 			o.RetryDelay = delay
+		}
+	}
+
+	// UnitRetryMaximumJitter defines the maximum jitter to utilize during
+	// retries that utilize random delay times.
+	UnitRetryMaximumJitter = func(jitter time.Duration) UnitOption {
+		return func(o *UnitOptions) {
+			o.RetryMaximumJitter = jitter
 		}
 	}
 

--- a/v4/unit_options.go
+++ b/v4/unit_options.go
@@ -33,7 +33,7 @@ type UnitOptions struct {
 	DataMappers                  map[TypeName]DataMapper
 	DB                           *sql.DB
 	RetryAttempts                int
-	RetryDelay                   *time.Duration
+	RetryDelay                   time.Duration
 	RetryType                    RetryType
 }
 
@@ -286,7 +286,7 @@ var (
 	// UnitRetryDelay defines the delay to utilize during retries.
 	UnitRetryDelay = func(delay time.Duration) UnitOption {
 		return func(o *UnitOptions) {
-			o.RetryDelay = &delay
+			o.RetryDelay = delay
 		}
 	}
 

--- a/v4/unit_options.go
+++ b/v4/unit_options.go
@@ -46,7 +46,7 @@ type RetryType int
 func (t RetryType) convert() retry.DelayTypeFunc {
 	types := map[RetryType]retry.DelayTypeFunc{
 		RetryTypeFixed:   retry.FixedDelay,
-		RetryTypeBackoff: retry.BackOffDelay,
+		RetryTypeBackOff: retry.BackOffDelay,
 		RetryTypeRandom:  retry.RandomDelay,
 	}
 	if converted, ok := types[t]; ok {
@@ -286,7 +286,7 @@ var (
 	// UnitRetryDelay defines the delay to utilize during retries.
 	UnitRetryDelay = func(delay time.Duration) UnitOption {
 		return func(o *UnitOptions) {
-			o.RetryDelay = delay
+			o.RetryDelay = &delay
 		}
 	}
 


### PR DESCRIPTION
**Description**

Introduces support retries as a means of bringing more resiliency to work units.

**Rationale**

When building distributed systems, individual system components are pushed to become more resilient. One such approach to achieving higher fault tolerance is to implement retries. These retries are typically useful in situations where the downstream being retried has experienced a transient failure (network issue, anomalous traffic, host resource constraint, etc.).

**Suggested Version**

`v4.1.0`

**Example Usage**

```go
...

opts :=
  []unit.Option{
    // other options...

    unit.RetryAttempts(3),
    unit.RetryDelay(150 * time.Millisecond),
    unit.RetryType(unit.RetryTypeFixed),
  }
u, err = unit.New(opts...)

...
```
