### PR TITLE
Rename 'RetryType' to 'UnitRetryType'.

### DIFF
--- a/v4/unit.go
+++ b/v4/unit.go
@@ -92,7 +92,7 @@ func options(options []UnitOption) UnitOptions {
 		Scope:              tally.NoopScope,
 		Actions:            make(map[UnitActionType][]UnitAction),
 		RetryAttempts:      3,
-		RetryType:          RetryTypeFixed,
+		RetryType:          UnitRetryDelayTypeFixed,
 		RetryDelay:         50 * time.Millisecond,
 		RetryMaximumJitter: 50 * time.Millisecond,
 	}

--- a/v4/unit/alias.go
+++ b/v4/unit/alias.go
@@ -59,6 +59,9 @@ type Option = work.UnitOption
 // Options represents the configuration options for the work unit.
 type Options = work.UnitOptions
 
+// RetryDelayType represents the type of retry delay to perform.
+type RetryDelayType = work.UnitRetryDelayType
+
 var (
 	// DB specifies the option to provide the database for the work unit.
 	DB = work.UnitDB

--- a/v4/unit_options.go
+++ b/v4/unit_options.go
@@ -35,20 +35,20 @@ type UnitOptions struct {
 	RetryAttempts                int
 	RetryDelay                   time.Duration
 	RetryMaximumJitter           time.Duration
-	RetryType                    RetryType
+	RetryType                    UnitRetryDelayType
 }
 
 // UnitOption applies an option to the provided configuration.
 type UnitOption func(*UnitOptions)
 
-// RetryType represents the type of retry to perform.
-type RetryType int
+// UnitRetryDelayType represents the type of retry delay to perform.
+type UnitRetryDelayType int
 
-func (t RetryType) convert() retry.DelayTypeFunc {
-	types := map[RetryType]retry.DelayTypeFunc{
-		RetryTypeFixed:   retry.FixedDelay,
-		RetryTypeBackOff: retry.BackOffDelay,
-		RetryTypeRandom:  retry.RandomDelay,
+func (t UnitRetryDelayType) convert() retry.DelayTypeFunc {
+	types := map[UnitRetryDelayType]retry.DelayTypeFunc{
+		UnitRetryDelayTypeFixed:   retry.FixedDelay,
+		UnitRetryDelayTypeBackOff: retry.BackOffDelay,
+		UnitRetryDelayTypeRandom:  retry.RandomDelay,
 	}
 	if converted, ok := types[t]; ok {
 		return converted
@@ -58,11 +58,11 @@ func (t RetryType) convert() retry.DelayTypeFunc {
 
 const (
 	// Fixed represents a retry type that maintains a constaint delay between retry iterations.
-	RetryTypeFixed = iota
+	UnitRetryDelayTypeFixed = iota
 	// BackOff represents a retry type that increases delay between retry iterations.
-	RetryTypeBackOff
+	UnitRetryDelayTypeBackOff
 	// Random represents a retry type that utilizes a random delay between retry iterations.
-	RetryTypeRandom
+	UnitRetryDelayTypeRandom
 )
 
 var (
@@ -300,7 +300,7 @@ var (
 	}
 
 	// UnitRetryType defines the type of retry to perform.
-	UnitRetryType = func(retryType RetryType) UnitOption {
+	UnitRetryType = func(retryType UnitRetryDelayType) UnitOption {
 		return func(o *UnitOptions) {
 			o.RetryType = retryType
 		}


### PR DESCRIPTION
**Description**

Renames `work.RetryType` to `work.UnitRetryDelayType`. Aliases `work.UnitRetryDelayType` as `unit.RetryDelayType`

**Rationale**

- Maintains consistency with existing type names.
- There is already an option called `work.UnitRetryType`, so `work.UnitRetryDelayType` is used to disambiguate.

**Suggested Version**

`v4.0.0-beta2`

**Example Usage**

```go
delayType := unit.RetryDelayTypeFixed
opts := []unit.Option{
  // ...
  unit.RetryType(delayType)
  // ...
}
u, err := unit.New(opts...)
```
