### PR TITLE
Update Travis CI configuration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,9 @@
 # Test binary, build with `go test -c`
 *.test
 
-# Output of the go coverage tool, specifically when used with LiteIDE
+# Output of the go coverage tool.
 *.out
+*.coverprofile
 
 # Dependency directory
 vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: go
 go:
-    - 1.12
+    - 1.14
 jobs:
   include:
     -
       stage: 'unit test'
       install:
         - go get golang.org/x/tools/cmd/cover
+        - go get github.com/modocache/gover
         - go get github.com/mattn/goveralls
-      before_script:
-        - 'curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh'
       script:
         - 'make test'
-        - '$HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN'
+        - 'gover'
+        - '$HOME/gopath/bin/goveralls -coverprofile=gover.coverprofile -service=travis-ci -repotoken $COVERALLS_TOKEN'

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,11 @@ bins:
 test: bins
 	@echo testing...
 	@#v1
-	@GO111MODULE=on go test -v -race -covermode=atomic -coverprofile=coverage.out github.com/freerware/work
+	@GO111MODULE=on go test -v -race -covermode=atomic -coverprofile=work.coverprofile github.com/freerware/work
 	@#v3
-	@cd ./v3 && GO111MODULE=on go test -v -race -covermode=atomic -coverprofile=coverage.out github.com/freerware/work/v3 && cd ..
+	@cd ./v3 && GO111MODULE=on go test -v -race -covermode=atomic -coverprofile=work.coverprofile github.com/freerware/work/v3 && cd ..
 	@#v4
-	@cd ./v4 && GO111MODULE=on go test -v -race -covermode=atomic -coverprofile=coverage.out github.com/freerware/work/v4 && cd ..
+	@cd ./v4 && GO111MODULE=on go test -v -race -covermode=atomic -coverprofile=work.coverprofile github.com/freerware/work/v4 && cd ..
 	@echo done!
 
 mocks:


### PR DESCRIPTION
**Description**

- Updates `.travis.yml` such that:
  - the desired `go` version is `1.14`.
  - it utilizes `gover`.
  - no longer utilizes `dep`.
- Updates `Makefile` to output `*.coverprofile` instead of `*.out`.

**Rationale**

- Test coverage reports were not working as expected.
- Specified `go` version was getting too old.

**Suggested Version**

`v4.0.0-beta`

**Example Usage**

N/A
