### PR TITLE
Modify .travis.yml to utilize codecov.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ jobs:
       script:
         - 'make test'
         - 'gover . coverage.txt'
-        - '$HOME/gopath/bin/goveralls -coverprofile=coverage.txt -service=travis-ci -repotoken $COVERALLS_TOKEN'
       after_success:
+        - '$HOME/gopath/bin/goveralls -coverprofile=coverage.txt -service=travis-ci -repotoken $COVERALLS_TOKEN'
         - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,7 @@ jobs:
         - go get github.com/mattn/goveralls
       script:
         - 'make test'
-        - 'gover'
-        - '$HOME/gopath/bin/goveralls -coverprofile=gover.coverprofile -service=travis-ci -repotoken $COVERALLS_TOKEN'
+        - 'gover . coverage.txt'
+        - '$HOME/gopath/bin/goveralls -coverprofile=coverage.txt -service=travis-ci -repotoken $COVERALLS_TOKEN'
+      after_success:
+        - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
**Description**

Modifies `.travis.yml` to utilize `codecov`.

**Rationale**

We have been having trouble with `coveralls` not being able to report line coverage correctly with `gover`. It consistently has issues identifying the wrong lines and not pulling in source altogether.

**Suggested Version**

`v4.0.0-beta.2`

**Example Usage**

N/A
