### PR TITLE
Remove integration with Coveralls.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,8 @@ jobs:
       install:
         - go get golang.org/x/tools/cmd/cover
         - go get github.com/modocache/gover
-        - go get github.com/mattn/goveralls
       script:
         - 'make test'
         - 'gover . coverage.txt'
       after_success:
-        - '$HOME/gopath/bin/goveralls -coverprofile=coverage.txt -service=travis-ci -repotoken $COVERALLS_TOKEN'
         - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ how we do things.
 [doc]: https://godoc.org/github.com/freerware/work
 [ci-img]: https://travis-ci.org/freerware/work.svg?branch=master
 [ci]: https://travis-ci.org/freerware/work
-[coverage-img]: https://coveralls.io/repos/github/freerware/work/badge.svg?branch=master
-[coverage]: https://coveralls.io/github/freerware/work?branch=master
+[coverage-img]: https://codecov.io/gh/freerware/work/branch/master/graph/badge.svg?token=W5YH9TPP3C
+[coverage]: https://codecov.io/gh/freerware/work
 [license]: https://opensource.org/licenses/Apache-2.0
 [license-img]: https://img.shields.io/badge/License-Apache%202.0-blue.svg
 [release]: https://github.com/freerware/work/releases


### PR DESCRIPTION
**Description**

Removes integration with `coveralls` from `.travis.yml`.

**Rationale**

Our switch to `codecov` has been successful and we are much happier :) .

**Suggested Version**

`v4.0.0-beta.2`

**Example Usage**

N/A
