### PR TITLE
Introduce retry attempt metric.

### DIFF
--- a/v4/best_effort_unit.go
+++ b/v4/best_effort_unit.go
@@ -281,6 +281,7 @@ func (u *bestEffortUnit) Save(ctx context.Context) (err error) {
 				zap.Int("attempt", int(attempt+1)),
 				zap.Error(err),
 			)
+			u.scope.Counter(retryAttempt).Inc(1)
 		})
 	u.retryOptions = append(u.retryOptions, retry.Context(ctx), onRetry)
 	err = retry.Do(func() error { return u.save(ctx) }, u.retryOptions...)

--- a/v4/best_effort_unit_test.go
+++ b/v4/best_effort_unit_test.go
@@ -52,6 +52,8 @@ type BestEffortUnitTestSuite struct {
 	rollbackScopeName                string
 	rollbackFailureScopeName         string
 	rollbackSuccessScopeName         string
+	retryAttemptScopeName            string
+	retryAttemptScopeNameWithTags    string
 	tags                             string
 
 	// suite state.
@@ -82,6 +84,8 @@ func (s *BestEffortUnitTestSuite) Setup() {
 	s.saveSuccessScopeNameWithTags = fmt.Sprintf("%s%s%s", s.saveSuccessScopeName, sep, s.tags)
 	s.rollbackSuccessScopeNameWithTags = fmt.Sprintf("%s%s%s", s.rollbackSuccessScopeName, sep, s.tags)
 	s.rollbackFailureScopeNameWithTags = fmt.Sprintf("%s%s%s", s.rollbackFailureScopeName, sep, s.tags)
+	s.retryAttemptScopeName = fmt.Sprintf("%s.%s", s.scopePrefix, "unit.retry.attempt")
+	s.retryAttemptScopeNameWithTags = fmt.Sprintf("%s%s%s", s.retryAttemptScopeName, sep, s.tags)
 
 	// test entities.
 	foo := Foo{ID: 28}
@@ -168,8 +172,9 @@ func (s *BestEffortUnitTestSuite) subtests() []TableDrivenTest {
 			ctx: context.Background(),
 			err: errors.New("whoa"),
 			assertions: func() {
-				s.Len(s.scope.Snapshot().Counters(), 1)
+				s.Len(s.scope.Snapshot().Counters(), 2)
 				s.Contains(s.scope.Snapshot().Counters(), s.rollbackSuccessScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.retryAttemptScopeNameWithTags)
 				s.Len(s.scope.Snapshot().Timers(), 2)
 				s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
 				s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)
@@ -214,8 +219,9 @@ func (s *BestEffortUnitTestSuite) subtests() []TableDrivenTest {
 			ctx: context.Background(),
 			err: errors.New("ouch; whoa"),
 			assertions: func() {
-				s.Len(s.scope.Snapshot().Counters(), 1)
+				s.Len(s.scope.Snapshot().Counters(), 2)
 				s.Contains(s.scope.Snapshot().Counters(), s.rollbackFailureScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.retryAttemptScopeNameWithTags)
 				s.Len(s.scope.Snapshot().Timers(), 2)
 				s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
 				s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)
@@ -278,8 +284,9 @@ func (s *BestEffortUnitTestSuite) subtests() []TableDrivenTest {
 			ctx: context.Background(),
 			err: errors.New("whoa"),
 			assertions: func() {
-				s.Len(s.scope.Snapshot().Counters(), 1)
+				s.Len(s.scope.Snapshot().Counters(), 2)
 				s.Contains(s.scope.Snapshot().Counters(), s.rollbackSuccessScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.retryAttemptScopeNameWithTags)
 				s.Len(s.scope.Snapshot().Timers(), 2)
 				s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
 				s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)
@@ -338,8 +345,9 @@ func (s *BestEffortUnitTestSuite) subtests() []TableDrivenTest {
 			ctx: context.Background(),
 			err: errors.New("ouch; whoa"),
 			assertions: func() {
-				s.Len(s.scope.Snapshot().Counters(), 1)
+				s.Len(s.scope.Snapshot().Counters(), 2)
 				s.Contains(s.scope.Snapshot().Counters(), s.rollbackFailureScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.retryAttemptScopeNameWithTags)
 				s.Len(s.scope.Snapshot().Timers(), 2)
 				s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
 				s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)
@@ -410,8 +418,9 @@ func (s *BestEffortUnitTestSuite) subtests() []TableDrivenTest {
 			ctx: context.Background(),
 			err: errors.New("whoa"),
 			assertions: func() {
-				s.Len(s.scope.Snapshot().Counters(), 1)
+				s.Len(s.scope.Snapshot().Counters(), 2)
 				s.Contains(s.scope.Snapshot().Counters(), s.rollbackSuccessScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.retryAttemptScopeNameWithTags)
 				s.Len(s.scope.Snapshot().Timers(), 2)
 				s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
 				s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)
@@ -478,8 +487,9 @@ func (s *BestEffortUnitTestSuite) subtests() []TableDrivenTest {
 			ctx: context.Background(),
 			err: errors.New("whoa; ouch"),
 			assertions: func() {
-				s.Len(s.scope.Snapshot().Counters(), 1)
+				s.Len(s.scope.Snapshot().Counters(), 2)
 				s.Contains(s.scope.Snapshot().Counters(), s.rollbackFailureScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.retryAttemptScopeNameWithTags)
 				s.Len(s.scope.Snapshot().Timers(), 2)
 				s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
 				s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)
@@ -859,8 +869,9 @@ func (s *BestEffortUnitTestSuite) subtests() []TableDrivenTest {
 			},
 			ctx: context.Background(),
 			assertions: func() {
-				s.Len(s.scope.Snapshot().Counters(), 2)
+				s.Len(s.scope.Snapshot().Counters(), 3)
 				s.Contains(s.scope.Snapshot().Counters(), s.saveSuccessScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.retryAttemptScopeNameWithTags)
 				s.Len(s.scope.Snapshot().Timers(), 2)
 				s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
 			},

--- a/v4/sql_unit_test.go
+++ b/v4/sql_unit_test.go
@@ -56,6 +56,8 @@ type SQLUnitTestSuite struct {
 	rollbackScopeName                string
 	rollbackFailureScopeName         string
 	rollbackSuccessScopeName         string
+	retryAttemptScopeName            string
+	retryAttemptScopeNameWithTags    string
 	tags                             string
 
 	// suite state.
@@ -86,6 +88,8 @@ func (s *SQLUnitTestSuite) Setup() {
 	s.saveSuccessScopeNameWithTags = fmt.Sprintf("%s%s%s", s.saveSuccessScopeName, sep, s.tags)
 	s.rollbackSuccessScopeNameWithTags = fmt.Sprintf("%s%s%s", s.rollbackSuccessScopeName, sep, s.tags)
 	s.rollbackFailureScopeNameWithTags = fmt.Sprintf("%s%s%s", s.rollbackFailureScopeName, sep, s.tags)
+	s.retryAttemptScopeName = fmt.Sprintf("%s.%s", s.scopePrefix, "unit.retry.attempt")
+	s.retryAttemptScopeNameWithTags = fmt.Sprintf("%s%s%s", s.retryAttemptScopeName, sep, s.tags)
 
 	// test entities.
 	foo := Foo{ID: 28}
@@ -164,8 +168,9 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 			ctx: context.Background(),
 			err: errors.New("whoa"),
 			assertions: func() {
-				s.Len(s.scope.Snapshot().Counters(), 1)
+				s.Len(s.scope.Snapshot().Counters(), 2)
 				s.Contains(s.scope.Snapshot().Counters(), s.rollbackSuccessScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.retryAttemptScopeNameWithTags)
 				s.Len(s.scope.Snapshot().Timers(), 1)
 				s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
 			},
@@ -201,8 +206,9 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 			ctx: context.Background(),
 			err: errors.New("whoa"),
 			assertions: func() {
-				s.Len(s.scope.Snapshot().Counters(), 1)
+				s.Len(s.scope.Snapshot().Counters(), 2)
 				s.Contains(s.scope.Snapshot().Counters(), s.rollbackSuccessScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.retryAttemptScopeNameWithTags)
 				s.Len(s.scope.Snapshot().Timers(), 2)
 				s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
 				s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)
@@ -239,8 +245,9 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 			ctx: context.Background(),
 			err: errors.New("ouch; whoa"),
 			assertions: func() {
-				s.Len(s.scope.Snapshot().Counters(), 1)
+				s.Len(s.scope.Snapshot().Counters(), 2)
 				s.Contains(s.scope.Snapshot().Counters(), s.rollbackFailureScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.retryAttemptScopeNameWithTags)
 				s.Len(s.scope.Snapshot().Timers(), 2)
 				s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
 				s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)
@@ -281,8 +288,9 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 			ctx: context.Background(),
 			err: errors.New("whoa"),
 			assertions: func() {
-				s.Len(s.scope.Snapshot().Counters(), 1)
+				s.Len(s.scope.Snapshot().Counters(), 2)
 				s.Contains(s.scope.Snapshot().Counters(), s.rollbackSuccessScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.retryAttemptScopeNameWithTags)
 				s.Len(s.scope.Snapshot().Timers(), 2)
 				s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
 				s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)
@@ -323,8 +331,9 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 			ctx: context.Background(),
 			err: errors.New("ouch; whoa"),
 			assertions: func() {
-				s.Len(s.scope.Snapshot().Counters(), 1)
+				s.Len(s.scope.Snapshot().Counters(), 2)
 				s.Contains(s.scope.Snapshot().Counters(), s.rollbackFailureScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.retryAttemptScopeNameWithTags)
 				s.Len(s.scope.Snapshot().Timers(), 2)
 				s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
 				s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)
@@ -369,8 +378,9 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 			ctx: context.Background(),
 			err: errors.New("whoa"),
 			assertions: func() {
-				s.Len(s.scope.Snapshot().Counters(), 1)
+				s.Len(s.scope.Snapshot().Counters(), 2)
 				s.Contains(s.scope.Snapshot().Counters(), s.rollbackSuccessScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.retryAttemptScopeNameWithTags)
 				s.Len(s.scope.Snapshot().Timers(), 2)
 				s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
 				s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)
@@ -415,8 +425,9 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 			ctx: context.Background(),
 			err: errors.New("whoa"),
 			assertions: func() {
-				s.Len(s.scope.Snapshot().Counters(), 1)
+				s.Len(s.scope.Snapshot().Counters(), 2)
 				s.Contains(s.scope.Snapshot().Counters(), s.rollbackFailureScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.retryAttemptScopeNameWithTags)
 				s.Len(s.scope.Snapshot().Timers(), 2)
 				s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
 				s.Contains(s.scope.Snapshot().Timers(), s.rollbackScopeNameWithTags)
@@ -545,8 +556,9 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 			ctx: context.Background(),
 			err: errors.New("whoa"),
 			assertions: func() {
-				s.Len(s.scope.Snapshot().Counters(), 1)
+				s.Len(s.scope.Snapshot().Counters(), 2)
 				s.Contains(s.scope.Snapshot().Counters(), s.rollbackSuccessScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.retryAttemptScopeNameWithTags)
 				s.Len(s.scope.Snapshot().Timers(), 1)
 				s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
 			},
@@ -641,8 +653,9 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 			},
 			ctx: context.Background(),
 			assertions: func() {
-				s.Len(s.scope.Snapshot().Counters(), 2)
+				s.Len(s.scope.Snapshot().Counters(), 3)
 				s.Contains(s.scope.Snapshot().Counters(), s.saveSuccessScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.retryAttemptScopeNameWithTags)
 				s.Len(s.scope.Snapshot().Timers(), 2)
 				s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
 			},


### PR DESCRIPTION
**Description**

Introduces support for the `unit.retry.attempt` metric.

**Rationale**

It can be useful for client to understand how many retries are executed within their units. This can provide insight as to whether retries are occurring during save operations.

**Suggested Version**

`v4.0.0-beta.2`

**Example Usage**

N/A
