### PR TITLE
Introduce metrics for successful unit inserts, updates, and deletes.

### DIFF
--- a/v4/best_effort_unit.go
+++ b/v4/best_effort_unit.go
@@ -268,6 +268,9 @@ func (u *bestEffortUnit) Save(ctx context.Context) (err error) {
 		}
 		if err == nil {
 			u.scope.Counter(saveSuccess).Inc(1)
+			u.scope.Counter(insert).Inc(int64(u.additionCount))
+			u.scope.Counter(update).Inc(int64(u.alterationCount))
+			u.scope.Counter(delete).Inc(int64(u.removalCount))
 			u.executeActions(UnitActionTypeAfterSave)
 		}
 	}()

--- a/v4/best_effort_unit_test.go
+++ b/v4/best_effort_unit_test.go
@@ -54,6 +54,12 @@ type BestEffortUnitTestSuite struct {
 	rollbackSuccessScopeName         string
 	retryAttemptScopeName            string
 	retryAttemptScopeNameWithTags    string
+	insertScopeName                  string
+	insertScopeNameWithTags          string
+	updateScopeName                  string
+	updateScopeNameWithTags          string
+	deleteScopeName                  string
+	deleteScopeNameWithTags          string
 	tags                             string
 
 	// suite state.
@@ -86,6 +92,12 @@ func (s *BestEffortUnitTestSuite) Setup() {
 	s.rollbackFailureScopeNameWithTags = fmt.Sprintf("%s%s%s", s.rollbackFailureScopeName, sep, s.tags)
 	s.retryAttemptScopeName = fmt.Sprintf("%s.%s", s.scopePrefix, "unit.retry.attempt")
 	s.retryAttemptScopeNameWithTags = fmt.Sprintf("%s%s%s", s.retryAttemptScopeName, sep, s.tags)
+	s.insertScopeName = fmt.Sprintf("%s.%s", s.scopePrefix, "unit.insert")
+	s.insertScopeNameWithTags = fmt.Sprintf("%s%s%s", s.insertScopeName, sep, s.tags)
+	s.updateScopeName = fmt.Sprintf("%s.%s", s.scopePrefix, "unit.update")
+	s.updateScopeNameWithTags = fmt.Sprintf("%s%s%s", s.updateScopeName, sep, s.tags)
+	s.deleteScopeName = fmt.Sprintf("%s.%s", s.scopePrefix, "unit.delete")
+	s.deleteScopeNameWithTags = fmt.Sprintf("%s%s%s", s.deleteScopeName, sep, s.tags)
 
 	// test entities.
 	foo := Foo{ID: 28}
@@ -770,8 +782,11 @@ func (s *BestEffortUnitTestSuite) subtests() []TableDrivenTest {
 			},
 			ctx: context.Background(),
 			assertions: func() {
-				s.Len(s.scope.Snapshot().Counters(), 1)
+				s.Len(s.scope.Snapshot().Counters(), 4)
 				s.Contains(s.scope.Snapshot().Counters(), s.saveSuccessScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.insertScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.updateScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.deleteScopeNameWithTags)
 				s.Len(s.scope.Snapshot().Timers(), 1)
 				s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
 			},
@@ -869,9 +884,12 @@ func (s *BestEffortUnitTestSuite) subtests() []TableDrivenTest {
 			},
 			ctx: context.Background(),
 			assertions: func() {
-				s.Len(s.scope.Snapshot().Counters(), 3)
+				s.Len(s.scope.Snapshot().Counters(), 6)
 				s.Contains(s.scope.Snapshot().Counters(), s.saveSuccessScopeNameWithTags)
 				s.Contains(s.scope.Snapshot().Counters(), s.retryAttemptScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.insertScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.updateScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.deleteScopeNameWithTags)
 				s.Len(s.scope.Snapshot().Timers(), 2)
 				s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
 			},

--- a/v4/sql_unit.go
+++ b/v4/sql_unit.go
@@ -188,6 +188,9 @@ func (u *sqlUnit) Save(ctx context.Context) (err error) {
 		}
 		if err == nil {
 			u.scope.Counter(saveSuccess).Inc(1)
+			u.scope.Counter(insert).Inc(int64(u.additionCount))
+			u.scope.Counter(update).Inc(int64(u.alterationCount))
+			u.scope.Counter(delete).Inc(int64(u.removalCount))
 			u.executeActions(UnitActionTypeAfterSave)
 		}
 	}()

--- a/v4/sql_unit_test.go
+++ b/v4/sql_unit_test.go
@@ -58,6 +58,12 @@ type SQLUnitTestSuite struct {
 	rollbackSuccessScopeName         string
 	retryAttemptScopeName            string
 	retryAttemptScopeNameWithTags    string
+	insertScopeName                  string
+	insertScopeNameWithTags          string
+	updateScopeName                  string
+	updateScopeNameWithTags          string
+	deleteScopeName                  string
+	deleteScopeNameWithTags          string
 	tags                             string
 
 	// suite state.
@@ -90,6 +96,12 @@ func (s *SQLUnitTestSuite) Setup() {
 	s.rollbackFailureScopeNameWithTags = fmt.Sprintf("%s%s%s", s.rollbackFailureScopeName, sep, s.tags)
 	s.retryAttemptScopeName = fmt.Sprintf("%s.%s", s.scopePrefix, "unit.retry.attempt")
 	s.retryAttemptScopeNameWithTags = fmt.Sprintf("%s%s%s", s.retryAttemptScopeName, sep, s.tags)
+	s.insertScopeName = fmt.Sprintf("%s.%s", s.scopePrefix, "unit.insert")
+	s.insertScopeNameWithTags = fmt.Sprintf("%s%s%s", s.insertScopeName, sep, s.tags)
+	s.updateScopeName = fmt.Sprintf("%s.%s", s.scopePrefix, "unit.update")
+	s.updateScopeNameWithTags = fmt.Sprintf("%s%s%s", s.updateScopeName, sep, s.tags)
+	s.deleteScopeName = fmt.Sprintf("%s.%s", s.scopePrefix, "unit.delete")
+	s.deleteScopeNameWithTags = fmt.Sprintf("%s%s%s", s.deleteScopeName, sep, s.tags)
 
 	// test entities.
 	foo := Foo{ID: 28}
@@ -596,8 +608,11 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 			},
 			ctx: context.Background(),
 			assertions: func() {
-				s.Len(s.scope.Snapshot().Counters(), 1)
+				s.Len(s.scope.Snapshot().Counters(), 4)
 				s.Contains(s.scope.Snapshot().Counters(), s.saveSuccessScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.insertScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.updateScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.deleteScopeNameWithTags)
 				s.Len(s.scope.Snapshot().Timers(), 1)
 				s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
 			},
@@ -653,9 +668,12 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 			},
 			ctx: context.Background(),
 			assertions: func() {
-				s.Len(s.scope.Snapshot().Counters(), 3)
+				s.Len(s.scope.Snapshot().Counters(), 6)
 				s.Contains(s.scope.Snapshot().Counters(), s.saveSuccessScopeNameWithTags)
 				s.Contains(s.scope.Snapshot().Counters(), s.retryAttemptScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.insertScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.updateScopeNameWithTags)
+				s.Contains(s.scope.Snapshot().Counters(), s.deleteScopeNameWithTags)
 				s.Len(s.scope.Snapshot().Timers(), 2)
 				s.Contains(s.scope.Snapshot().Timers(), s.saveScopeNameWithTags)
 			},

--- a/v4/unit.go
+++ b/v4/unit.go
@@ -27,6 +27,7 @@ import (
 	"go.uber.org/zap"
 )
 
+// Metric scope name definitions.
 const (
 	rollbackSuccess = "rollback.success"
 	rollbackFailure = "rollback.failure"
@@ -34,6 +35,9 @@ const (
 	save            = "save"
 	rollback        = "rollback"
 	retryAttempt    = "retry.attempt"
+	insert          = "insert"
+	update          = "update"
+	delete          = "delete"
 )
 
 var (


### PR DESCRIPTION
**Description**

Introduce the following metrics that track successful inserts, updates, and deletes.
- `unit.insert`
- `unit.update`
- `unit.delete`

**Rationale**

These metrics can provide a means of understand unit throughput, as they communicate the amount of entities involved in unit operations.

**Suggested Version**

`v4.0.0-beta.2`

**Example Usage**

N/A
