### PR TITLE
Update go documentation badge to leverage pkg.go.dev.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ how we do things.
 [code-of-conduct]: https://github.com/freerware/work/blob/master/CODE_OF_CONDUCT.md
 [concurrency-pr]: https://github.com/freerware/work/pull/35
 [actions-pr]: https://github.com/freerware/work/pull/30
-[doc-img]: https://godoc.org/github.com/freerware/work?status.svg
-[doc]: https://godoc.org/github.com/freerware/work
+[doc-img]: https://pkg.go.dev/badge/github.com/freerware/work/v4.svg
+[doc]: https://pkg.go.dev/github.com/freerware/work/v4
 [ci-img]: https://travis-ci.org/freerware/work.svg?branch=master
 [ci]: https://travis-ci.org/freerware/work
 [coverage-img]: https://codecov.io/gh/freerware/work/branch/master/graph/badge.svg?token=W5YH9TPP3C

--- a/v4/README.md
+++ b/v4/README.md
@@ -149,8 +149,8 @@ u, err := uniter.Unit()
 [contributing]: https://github.com/freerware/work/blob/master/CONTRIBUTING.md
 [apache-license]: https://github.com/freerware/work/blob/master/LICENSE.txt
 [code-of-conduct]: https://github.com/freerware/work/blob/master/CODE_OF_CONDUCT.md
-[doc-img]: https://godoc.org/github.com/freerware/work?status.svg
-[doc]: https://godoc.org/github.com/freerware/work
+[doc-img]: https://pkg.go.dev/badge/github.com/freerware/work/v4.svg
+[doc]: https://pkg.go.dev/github.com/freerware/work/v4
 [ci-img]: https://travis-ci.org/freerware/work.svg?branch=master
 [ci]: https://travis-ci.org/freerware/work
 [coverage-img]: https://coveralls.io/repos/github/freerware/work/badge.svg?branch=master


### PR DESCRIPTION
**Description**

Updates the `README.md` files to utilize `pkg.go.dev`.

**Rationale**

`pkg.go.dev` is the future!

**Suggested Version**

`v4.0.0-beta.2

**Example Usage**

N/A
