### PR TITLE
Update file headers to include current year.

### DIFF
--- a/v3/best_effort_unit.go
+++ b/v3/best_effort_unit.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/best_effort_unit_test.go
+++ b/v3/best_effort_unit_test.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/best_effort_uniter.go
+++ b/v3/best_effort_uniter.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/best_effort_uniter_test.go
+++ b/v3/best_effort_uniter_test.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/data_mapper.go
+++ b/v3/data_mapper.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/sql_data_mapper.go
+++ b/v3/sql_data_mapper.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/sql_unit.go
+++ b/v3/sql_unit.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/sql_unit_test.go
+++ b/v3/sql_unit_test.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/sql_uniter.go
+++ b/v3/sql_uniter.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/sql_uniter_test.go
+++ b/v3/sql_uniter_test.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/type_name.go
+++ b/v3/type_name.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/unit.go
+++ b/v3/unit.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/unit_action.go
+++ b/v3/unit_action.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/unit_action_context.go
+++ b/v3/unit_action_context.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/unit_options.go
+++ b/v3/unit_options.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/unit_options_test.go
+++ b/v3/unit_options_test.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/uniter.go
+++ b/v3/uniter.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v3/work_test.go
+++ b/v3/work_test.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v4/benchmarks_test.go
+++ b/v4/benchmarks_test.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v4/best_effort_unit.go
+++ b/v4/best_effort_unit.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v4/best_effort_unit_test.go
+++ b/v4/best_effort_unit_test.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v4/data_mapper.go
+++ b/v4/data_mapper.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v4/mapper_context.go
+++ b/v4/mapper_context.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v4/sql_unit.go
+++ b/v4/sql_unit.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v4/sql_unit_test.go
+++ b/v4/sql_unit_test.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v4/type_name.go
+++ b/v4/type_name.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v4/unit.go
+++ b/v4/unit.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v4/unit/alias.go
+++ b/v4/unit/alias.go
@@ -1,4 +1,4 @@
-/* Copyright 2020 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v4/unit_action.go
+++ b/v4/unit_action.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v4/unit_action_context.go
+++ b/v4/unit_action_context.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v4/unit_options.go
+++ b/v4/unit_options.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v4/unit_options_test.go
+++ b/v4/unit_options_test.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v4/unit_test.go
+++ b/v4/unit_test.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v4/uniter.go
+++ b/v4/uniter.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v4/uniter_test.go
+++ b/v4/uniter_test.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/v4/work_test.go
+++ b/v4/work_test.go
@@ -1,4 +1,4 @@
-/* Copyright 2021 Freerware
+/* Copyright 2022 Freerware
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
**Description**

Updates the license header information in each file to indicate a copyright for `2022`.

**Rationale**

Time is a thing.

**Suggested Version**

N/A - No change in functionality.

**Example Usage**

N/A - No change in functionality.
