### PR TITLE
Introduce InsertFunc, UpdateFunc, and DeleteFunc options.

### DIFF
--- a/v4/best_effort_unit.go
+++ b/v4/best_effort_unit.go
@@ -123,11 +123,11 @@ func (u *bestEffortUnit) applyInserts(ctx context.Context, mCtx MapperContext) (
 		if f, ok := u.insertFunc(typeName); ok {
 			if err = f(ctx, mCtx, additions...); err != nil {
 				u.executeActions(UnitActionTypeBeforeRollback)
-				errorRollback := u.rollback(ctx, mCtx)
-				if errorRollback == nil {
+				errRollback := u.rollback(ctx, mCtx)
+				if errRollback == nil {
 					u.executeActions(UnitActionTypeAfterRollback)
 				}
-				err = multierr.Combine(err, errorRollback)
+				err = multierr.Combine(err, errRollback)
 				u.logger.Error(err.Error(), zap.String("typeName", typeName.String()))
 				return
 			}
@@ -147,11 +147,11 @@ func (u *bestEffortUnit) applyUpdates(ctx context.Context, mCtx MapperContext) (
 		if f, ok := u.updateFunc(typeName); ok {
 			if err = f(ctx, mCtx, alterations...); err != nil {
 				u.executeActions(UnitActionTypeBeforeRollback)
-				errorRollback := u.rollback(ctx, mCtx)
-				if errorRollback == nil {
+				errRollback := u.rollback(ctx, mCtx)
+				if errRollback == nil {
 					u.executeActions(UnitActionTypeAfterRollback)
 				}
-				err = multierr.Combine(err, errorRollback)
+				err = multierr.Combine(err, errRollback)
 				u.logger.Error(err.Error(), zap.String("typeName", typeName.String()))
 				return
 			}
@@ -171,11 +171,11 @@ func (u *bestEffortUnit) applyDeletes(ctx context.Context, mCtx MapperContext) (
 		if f, ok := u.deleteFunc(typeName); ok {
 			if err = f(ctx, mCtx, removals...); err != nil {
 				u.executeActions(UnitActionTypeBeforeRollback)
-				errorRollback := u.rollback(ctx, mCtx)
-				if errorRollback == nil {
+				errRollback := u.rollback(ctx, mCtx)
+				if errRollback == nil {
 					u.executeActions(UnitActionTypeAfterRollback)
 				}
-				err = multierr.Combine(err, errorRollback)
+				err = multierr.Combine(err, errRollback)
 				u.logger.Error(err.Error(), zap.String("typeName", typeName.String()))
 				return
 			}

--- a/v4/best_effort_unit.go
+++ b/v4/best_effort_unit.go
@@ -45,14 +45,11 @@ func (u *bestEffortUnit) rollbackInserts(ctx context.Context, mCtx MapperContext
 	//delete successfully inserted entities.
 	u.logger.Debug("attempting to rollback inserted entities", zap.Int("count", u.successfulInsertCount))
 	for typeName, i := range u.successfulInserts {
-		var m DataMapper
-		m, err = u.mapper(typeName)
-		if err != nil {
-			return
-		}
-		if err = m.Delete(ctx, mCtx, i...); err != nil {
-			u.logger.Error(err.Error(), zap.String("typeName", typeName.String()))
-			return
+		if f, ok := u.deleteFunc(typeName); ok {
+			if err = f(ctx, mCtx, i...); err != nil {
+				u.logger.Error(err.Error(), zap.String("typeName", typeName.String()))
+				return
+			}
 		}
 	}
 	return nil
@@ -62,14 +59,11 @@ func (u *bestEffortUnit) rollbackUpdates(ctx context.Context, mCtx MapperContext
 	//reapply previously registered state for the entities.
 	u.logger.Debug("attempting to rollback updated entities", zap.Int("count", u.successfulUpdateCount))
 	for typeName, r := range u.registered {
-		var m DataMapper
-		m, err = u.mapper(typeName)
-		if err != nil {
-			return
-		}
-		if err = m.Update(ctx, mCtx, r...); err != nil {
-			u.logger.Error(err.Error(), zap.String("typeName", typeName.String()))
-			return
+		if f, ok := u.updateFunc(typeName); ok {
+			if err = f(ctx, mCtx, r...); err != nil {
+				u.logger.Error(err.Error(), zap.String("typeName", typeName.String()))
+				return
+			}
 		}
 	}
 	return
@@ -79,14 +73,11 @@ func (u *bestEffortUnit) rollbackDeletes(ctx context.Context, mCtx MapperContext
 	//reinsert successfully deleted entities.
 	u.logger.Debug("attempting to rollback deleted entities", zap.Int("count", u.successfulDeleteCount))
 	for typeName, d := range u.successfulDeletes {
-		var m DataMapper
-		m, err = u.mapper(typeName)
-		if err != nil {
-			return
-		}
-		if err = m.Insert(ctx, mCtx, d...); err != nil {
-			u.logger.Error(err.Error(), zap.String("typeName", typeName.String()))
-			return
+		if f, ok := u.insertFunc(typeName); ok {
+			if err = f(ctx, mCtx, d...); err != nil {
+				u.logger.Error(err.Error(), zap.String("typeName", typeName.String()))
+				return
+			}
 		}
 	}
 	return
@@ -129,81 +120,72 @@ func (u *bestEffortUnit) rollback(ctx context.Context, mCtx MapperContext) (err 
 
 func (u *bestEffortUnit) applyInserts(ctx context.Context, mCtx MapperContext) (err error) {
 	for typeName, additions := range u.additions {
-		var m DataMapper
-		m, err = u.mapper(typeName)
-		if err != nil {
-			return
-		}
-		if err = m.Insert(ctx, mCtx, additions...); err != nil {
-			u.executeActions(UnitActionTypeBeforeRollback)
-			var errRb error
-			if errRb = u.rollback(ctx, mCtx); errRb == nil {
-				u.executeActions(UnitActionTypeAfterRollback)
+		if f, ok := u.insertFunc(typeName); ok {
+			if err = f(ctx, mCtx, additions...); err != nil {
+				u.executeActions(UnitActionTypeBeforeRollback)
+				errorRollback := u.rollback(ctx, mCtx)
+				if errorRollback == nil {
+					u.executeActions(UnitActionTypeAfterRollback)
+				}
+				err = multierr.Combine(err, errorRollback)
+				u.logger.Error(err.Error(), zap.String("typeName", typeName.String()))
+				return
 			}
-			err = multierr.Combine(err, errRb)
-			u.logger.Error(err.Error(), zap.String("typeName", typeName.String()))
-			return
+			if _, ok := u.successfulInserts[typeName]; !ok {
+				u.successfulInserts[typeName] = []interface{}{}
+			}
+			u.successfulInserts[typeName] =
+				append(u.successfulInserts[typeName], additions...)
+			u.successfulInsertCount = u.successfulInsertCount + len(additions)
 		}
-		if _, ok := u.successfulInserts[typeName]; !ok {
-			u.successfulInserts[typeName] = []interface{}{}
-		}
-		u.successfulInserts[typeName] =
-			append(u.successfulInserts[typeName], additions...)
-		u.successfulInsertCount = u.successfulInsertCount + len(additions)
 	}
 	return
 }
 
 func (u *bestEffortUnit) applyUpdates(ctx context.Context, mCtx MapperContext) (err error) {
 	for typeName, alterations := range u.alterations {
-		var m DataMapper
-		m, err = u.mapper(typeName)
-		if err != nil {
-			return
-		}
-		if err = m.Update(ctx, mCtx, alterations...); err != nil {
-			u.executeActions(UnitActionTypeBeforeRollback)
-			var errRb error
-			if errRb = u.rollback(ctx, mCtx); errRb == nil {
-				u.executeActions(UnitActionTypeAfterRollback)
+		if f, ok := u.updateFunc(typeName); ok {
+			if err = f(ctx, mCtx, alterations...); err != nil {
+				u.executeActions(UnitActionTypeBeforeRollback)
+				errorRollback := u.rollback(ctx, mCtx)
+				if errorRollback == nil {
+					u.executeActions(UnitActionTypeAfterRollback)
+				}
+				err = multierr.Combine(err, errorRollback)
+				u.logger.Error(err.Error(), zap.String("typeName", typeName.String()))
+				return
 			}
-			err = multierr.Combine(err, errRb)
-			u.logger.Error(err.Error(), zap.String("typeName", typeName.String()))
-			return
+			if _, ok := u.successfulUpdates[typeName]; !ok {
+				u.successfulUpdates[typeName] = []interface{}{}
+			}
+			u.successfulUpdates[typeName] =
+				append(u.successfulUpdates[typeName], alterations...)
+			u.successfulUpdateCount = u.successfulUpdateCount + len(alterations)
 		}
-		if _, ok := u.successfulUpdates[typeName]; !ok {
-			u.successfulUpdates[typeName] = []interface{}{}
-		}
-		u.successfulUpdates[typeName] =
-			append(u.successfulUpdates[typeName], alterations...)
-		u.successfulUpdateCount = u.successfulUpdateCount + len(alterations)
 	}
 	return
 }
 
 func (u *bestEffortUnit) applyDeletes(ctx context.Context, mCtx MapperContext) (err error) {
 	for typeName, removals := range u.removals {
-		var m DataMapper
-		m, err = u.mapper(typeName)
-		if err != nil {
-			return
-		}
-		if err = m.Delete(ctx, mCtx, removals...); err != nil {
-			u.executeActions(UnitActionTypeBeforeRollback)
-			var errRb error
-			if errRb = u.rollback(ctx, mCtx); errRb == nil {
-				u.executeActions(UnitActionTypeAfterRollback)
+		if f, ok := u.deleteFunc(typeName); ok {
+			if err = f(ctx, mCtx, removals...); err != nil {
+				u.executeActions(UnitActionTypeBeforeRollback)
+				errorRollback := u.rollback(ctx, mCtx)
+				if errorRollback == nil {
+					u.executeActions(UnitActionTypeAfterRollback)
+				}
+				err = multierr.Combine(err, errorRollback)
+				u.logger.Error(err.Error(), zap.String("typeName", typeName.String()))
+				return
 			}
-			err = multierr.Combine(err, errRb)
-			u.logger.Error(err.Error(), zap.String("typeName", typeName.String()))
-			return
+			if _, ok := u.successfulDeletes[typeName]; !ok {
+				u.successfulDeletes[typeName] = []interface{}{}
+			}
+			u.successfulDeletes[typeName] =
+				append(u.successfulDeletes[typeName], removals...)
+			u.successfulDeleteCount = u.successfulDeleteCount + len(removals)
 		}
-		if _, ok := u.successfulDeletes[typeName]; !ok {
-			u.successfulDeletes[typeName] = []interface{}{}
-		}
-		u.successfulDeletes[typeName] =
-			append(u.successfulDeletes[typeName], removals...)
-		u.successfulDeleteCount = u.successfulDeleteCount + len(removals)
 	}
 	return
 }

--- a/v4/sql_unit_test.go
+++ b/v4/sql_unit_test.go
@@ -413,10 +413,10 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 				s.mappers[barType].EXPECT().Insert(ctx, gomock.Any(), additions[1]).Return(nil).Times(s.retryCount)
 				s.mappers[fooType].EXPECT().Update(ctx, gomock.Any(), alters[0]).Return(nil).Times(s.retryCount)
 				s.mappers[barType].EXPECT().Update(ctx, gomock.Any(), alters[1]).Return(nil).Times(s.retryCount)
-				s.mappers[fooType].EXPECT().Delete(ctx, gomock.Any(), removals[0]).Return(errors.New("whoa")).Times(s.retryCount)
+				s.mappers[fooType].EXPECT().Delete(ctx, gomock.Any(), removals[0]).Return(errors.New("ouch")).Times(s.retryCount)
 			},
 			ctx:        context.Background(),
-			err:        errors.New("whoa"),
+			err:        errors.New("ouch; whoa"),
 			assertions: func() {},
 		},
 		{
@@ -433,10 +433,10 @@ func (s *SQLUnitTestSuite) subtests() []TableDrivenTest {
 				s.mappers[barType].EXPECT().Insert(ctx, gomock.Any(), additions[1]).Return(nil).Times(s.retryCount)
 				s.mappers[fooType].EXPECT().Update(ctx, gomock.Any(), alters[0]).Return(nil).Times(s.retryCount)
 				s.mappers[barType].EXPECT().Update(ctx, gomock.Any(), alters[1]).Return(nil).Times(s.retryCount)
-				s.mappers[fooType].EXPECT().Delete(ctx, gomock.Any(), removals[0]).Return(errors.New("whoa")).Times(s.retryCount)
+				s.mappers[fooType].EXPECT().Delete(ctx, gomock.Any(), removals[0]).Return(errors.New("ouch")).Times(s.retryCount)
 			},
 			ctx: context.Background(),
-			err: errors.New("whoa"),
+			err: errors.New("ouch; whoa"),
 			assertions: func() {
 				s.Len(s.scope.Snapshot().Counters(), 2)
 				s.Contains(s.scope.Snapshot().Counters(), s.rollbackFailureScopeNameWithTags)

--- a/v4/unit.go
+++ b/v4/unit.go
@@ -47,11 +47,11 @@ var (
 	// ErrMissingDataMapper represents the error that is returned
 	// when attempting to add, alter, remove, or register an entity
 	// that doesn't have a corresponding data mapper.
-	ErrMissingDataMapper = errors.New("missing data mapper for entity")
+	ErrMissingDataMapper = errors.New("missing data mapper or data mapper function for entity")
 
 	// ErrNoDataMapper represents the error that occurs when attempting
 	// to create a work unit without any data mappers.
-	ErrNoDataMapper = errors.New("must have at least one data mapper")
+	ErrNoDataMapper = errors.New("must have at least one data mapper or data mapper function")
 )
 
 // Unit represents an atomic set of entity changes.

--- a/v4/unit/alias.go
+++ b/v4/unit/alias.go
@@ -127,6 +127,15 @@ var (
 	RetryMaximumJitter = work.UnitRetryMaximumJitter
 	// RetryType defines the type of retry to perform.
 	RetryType = work.UnitRetryType
+	// InsertFunc defines the function to be used for inserting new
+	// entities in the underlying data store.
+	InsertFunc = work.UnitInsertFunc
+	// UpdateFunc defines the function to be used for updating existing
+	// entities in the underlying data store.
+	UpdateFunc = work.UnitUpdateFunc
+	// DeleteFunc defines the function to be used for deleting existing
+	// entities in the underlying data store.
+	DeleteFunc = work.UnitDeleteFunc
 )
 
 /* Actions. */
@@ -203,3 +212,7 @@ type MapperContext = work.MapperContext
 
 // DataMapper represents a creator, modifier, and deleter of entities.
 type DataMapper = work.DataMapper
+
+// DataMapperFunc represents a data mapper function that performs a single
+// operation, such as insert, update, or delete.
+type DataMapperFunc = work.UnitDataMapperFunc

--- a/v4/unit_options_test.go
+++ b/v4/unit_options_test.go
@@ -21,6 +21,9 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/freerware/work/v4"
+	"github.com/freerware/work/v4/internal/mock"
+	"github.com/freerware/work/v4/internal/test"
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
@@ -60,18 +63,25 @@ func (s *UnitOptionsTestSuite) TestUnitDataMappers_Nil() {
 	work.UnitDataMappers(dm)(s.sut)
 
 	// assert.
-	s.Nil(s.sut.DataMappers)
+	s.Nil(s.sut.InsertFuncs)
+	s.Nil(s.sut.UpdateFuncs)
+	s.Nil(s.sut.DeleteFuncs)
 }
 
 func (s *UnitOptionsTestSuite) TestUnitDataMappers_NotNil() {
 	// arrange.
 	dm := make(map[work.TypeName]work.DataMapper)
+	mc := gomock.NewController(s.T())
+	fooTypeName := work.TypeNameOf(test.Foo{})
+	dm[fooTypeName] = mock.NewDataMapper(mc)
 
 	// action.
 	work.UnitDataMappers(dm)(s.sut)
 
 	// assert.
-	s.NotNil(s.sut.DataMappers)
+	s.NotNil(s.sut.InsertFuncs)
+	s.NotNil(s.sut.UpdateFuncs)
+	s.NotNil(s.sut.DeleteFuncs)
 }
 
 func (s *UnitOptionsTestSuite) TestUnitLogger() {

--- a/v4/unit_options_test.go
+++ b/v4/unit_options_test.go
@@ -84,6 +84,42 @@ func (s *UnitOptionsTestSuite) TestUnitDataMappers_NotNil() {
 	s.NotNil(s.sut.DeleteFuncs)
 }
 
+func (s *UnitOptionsTestSuite) TestUnitInsertFunc() {
+	// arrange.
+	t := work.TypeNameOf(test.Foo{})
+	var f work.UnitDataMapperFunc
+
+	// action.
+	work.UnitInsertFunc(t, f)(s.sut)
+
+	// assert.
+	s.NotNil(s.sut.InsertFuncs)
+}
+
+func (s *UnitOptionsTestSuite) TestUnitUpdateFunc() {
+	// arrange.
+	t := work.TypeNameOf(test.Foo{})
+	var f work.UnitDataMapperFunc
+
+	// action.
+	work.UnitUpdateFunc(t, f)(s.sut)
+
+	// assert.
+	s.NotNil(s.sut.UpdateFuncs)
+}
+
+func (s *UnitOptionsTestSuite) TestUnitDeleteFunc() {
+	// arrange.
+	t := work.TypeNameOf(test.Foo{})
+	var f work.UnitDataMapperFunc
+
+	// action.
+	work.UnitDeleteFunc(t, f)(s.sut)
+
+	// assert.
+	s.NotNil(s.sut.DeleteFuncs)
+}
+
 func (s *UnitOptionsTestSuite) TestUnitLogger() {
 	// arrange.
 	c := zap.NewDevelopmentConfig()


### PR DESCRIPTION
**Description**

Introduces the `work.UnitInsertFunc`, `work.UnitUpdateFunc`, and `work.UnitDeleteFunc` options. Additionally refactors the `work.SQLUnit` and `work.BestEffortUnit` to leverage `work.UnitDataMapperFunc` internally instead of `work.DataMapper`.

**Rationale**

See #60 .

**Suggested Version**

`v4.0.0-beta.5`

**Example Usage**

```go
// entities.
f := Foo{}

// type names.
ft := unit.TypeNameOf(f)

// 🎉
opts = []unit.Option{
  unit.DB(db),
  unit.InsertFunc(ft, func(ctx context.Context, mCtx unit.MapperContext, entities ...interface{}) error {
    // insertion data mapper logic.
  }),
  unit.UpdateFunc(ft, func(ctx context.Context, mCtx unit.MapperContext, entities ...interface{}) error {
    // update data mapper logic.
  }),
  unit.DeleteFunc(ft, func(ctx context.Context, mCtx unit.MapperContext, entities ...interface{}) error {
    // deletion data mapper logic.
  }),
}
unit, err := unit.New(opts...)
```
