### PR TITLE
Fix bug preventing unit creation.

### DIFF
--- a/v4/unit_options.go
+++ b/v4/unit_options.go
@@ -386,6 +386,7 @@ var (
 				o.InsertFuncs = make(map[TypeName]UnitDataMapperFunc)
 			}
 			o.InsertFuncs[t] = insertFunc
+			o.insertFuncsLen = o.insertFuncsLen + 1
 		}
 	}
 
@@ -397,6 +398,7 @@ var (
 				o.UpdateFuncs = make(map[TypeName]UnitDataMapperFunc)
 			}
 			o.UpdateFuncs[t] = updateFunc
+			o.updateFuncsLen = o.updateFuncsLen + 1
 		}
 	}
 
@@ -408,6 +410,7 @@ var (
 				o.DeleteFuncs = make(map[TypeName]UnitDataMapperFunc)
 			}
 			o.DeleteFuncs[t] = deleteFunc
+			o.deleteFuncsLen = o.deleteFuncsLen + 1
 		}
 	}
 )

--- a/v4/unit_test.go
+++ b/v4/unit_test.go
@@ -105,6 +105,66 @@ func (s *UnitTestSuite) TestUnit_NewUnit_NoDataMappers() {
 	s.EqualError(err, work.ErrNoDataMapper.Error())
 }
 
+func (s *UnitTestSuite) TestUnit_NewUnit_WithDataMappers() {
+
+	// action.
+	var err error
+	mappers := map[work.TypeName]work.UnitDataMapper{
+		work.TypeNameOf(test.Bar{}): &mock.UnitDataMapper{},
+	}
+	opts := []work.UnitOption{work.UnitDataMappers(mappers)}
+	s.sut, err = work.NewUnit(opts...)
+
+	// assert.
+	s.NoError(err, work.ErrNoDataMapper.Error())
+	s.NotNil(s.sut)
+}
+
+func (s *UnitTestSuite) TestUnit_NewUnit_NoDataMapperFunctions() {
+
+	// action.
+	var err error
+	s.sut, err = work.NewUnit()
+
+	// assert.
+	s.EqualError(err, work.ErrNoDataMapper.Error())
+}
+
+func (s *UnitTestSuite) TestUnit_NewUnit_WithSomeDataMapperFuncs() {
+
+	// action.
+	var err error
+	mapper := &mock.UnitDataMapper{}
+	t := work.TypeNameOf(test.Bar{})
+	opts := []work.UnitOption{
+		work.UnitInsertFunc(t, mapper.Insert),
+		work.UnitUpdateFunc(t, mapper.Update),
+	}
+	s.sut, err = work.NewUnit(opts...)
+
+	// assert.
+	s.NoError(err, work.ErrNoDataMapper.Error())
+	s.NotNil(s.sut)
+}
+
+func (s *UnitTestSuite) TestUnit_NewUnit_WithAllDataMapperFuncs() {
+
+	// action.
+	var err error
+	mapper := &mock.UnitDataMapper{}
+	t := work.TypeNameOf(test.Bar{})
+	opts := []work.UnitOption{
+		work.UnitInsertFunc(t, mapper.Insert),
+		work.UnitUpdateFunc(t, mapper.Update),
+		work.UnitDeleteFunc(t, mapper.Delete),
+	}
+	s.sut, err = work.NewUnit(opts...)
+
+	// assert.
+	s.NoError(err, work.ErrNoDataMapper.Error())
+	s.NotNil(s.sut)
+}
+
 func (s *UnitTestSuite) TestUnit_Add_Empty() {
 
 	// arrange.

--- a/v4/unit_test.go
+++ b/v4/unit_test.go
@@ -116,7 +116,7 @@ func (s *UnitTestSuite) TestUnit_NewUnit_WithDataMappers() {
 	s.sut, err = work.NewUnit(opts...)
 
 	// assert.
-	s.NoError(err, work.ErrNoDataMapper.Error())
+	s.NoError(err)
 	s.NotNil(s.sut)
 }
 
@@ -143,7 +143,7 @@ func (s *UnitTestSuite) TestUnit_NewUnit_WithSomeDataMapperFuncs() {
 	s.sut, err = work.NewUnit(opts...)
 
 	// assert.
-	s.NoError(err, work.ErrNoDataMapper.Error())
+	s.NoError(err)
 	s.NotNil(s.sut)
 }
 
@@ -161,7 +161,7 @@ func (s *UnitTestSuite) TestUnit_NewUnit_WithAllDataMapperFuncs() {
 	s.sut, err = work.NewUnit(opts...)
 
 	// assert.
-	s.NoError(err, work.ErrNoDataMapper.Error())
+	s.NoError(err)
 	s.NotNil(s.sut)
 }
 


### PR DESCRIPTION
**Description**

I accidentally introduced a bug that surfaces when only using data mapper functions when creating work units. Doing so causes a sanity check during construction to determine that no data mapping functionality has been specified, when in actuality it has.

**Suggested Version**

`v4.0.0-beta.6`

**Example Usage**

N/A
