### PR TITLE
Introduce initial version of continuous benchmarking.

### DIFF
--- a/.github/workflows/cb.yaml
+++ b/.github/workflows/cb.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Run benchmark
         run: make benchmark | tee output.txt
       - name: Download previous benchmark data
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ./cache
           key: ${{ runner.os }}-benchmark

--- a/.github/workflows/cb.yaml
+++ b/.github/workflows/cb.yaml
@@ -32,5 +32,6 @@ jobs:
           external-data-json-path: ./cache/benchmark-data.json
           fail-on-alert: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-always: true
           comment-on-alert: true
           alert-comment-cc-users: '@fr33r'

--- a/.github/workflows/cb.yaml
+++ b/.github/workflows/cb.yaml
@@ -1,0 +1,37 @@
+name: Example for minimal setup
+on: [push]
+
+permissions:
+  contents: write
+  deployments: write
+
+jobs:
+  benchmark:
+    name: Benchmark
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ '1.18' ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Run benchmark
+        run: make benchmark | tee output.txt
+      - name: Download previous benchmark data
+        uses: actions/cache@v1
+        with:
+          path: ./cache
+          key: ${{ runner.os }}-benchmark
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: 'go'
+          output-file-path: output.txt
+          external-data-json-path: ./cache/benchmark-data.json
+          fail-on-alert: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-on-alert: true
+          alert-comment-cc-users: '@fr33r'

--- a/.github/workflows/cb.yaml
+++ b/.github/workflows/cb.yaml
@@ -1,4 +1,4 @@
-name: Example for minimal setup
+name: CB
 on: [push]
 
 permissions:
@@ -6,8 +6,7 @@ permissions:
   deployments: write
 
 jobs:
-  benchmark:
-    name: Benchmark
+  benchmarks:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,14 +3,11 @@ name: CI
 on: [push]
 
 jobs:
-
   tests-v3:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
         go-version: [ '1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19' ]
-
     steps:
       - uses: actions/checkout@v3
       - name: Setup Go ${{ matrix.go-version }}
@@ -29,14 +26,11 @@ jobs:
           flags: v3
           fail_ci_if_error: true
           verbose: true
-
   tests-v4:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
         go-version: [ '1.18', '1.19' ]
-
     steps:
       - uses: actions/checkout@v3
       - name: Setup Go ${{ matrix.go-version }}


### PR DESCRIPTION
**Description**

Leverages the `benchmark-action/github-action-benchmark@v1` [GitHub action](https://github.com/benchmark-action/github-action-benchmark) to automatically run the `v4` benchmark suite when any push occurs. This action will additionally fail the changes in the event the benchmark is 2x slower than a previous run.

This work tackles #70 .

**Rationale**

Keeping track of performance regressions requires tracking performance before and after changes are applied. This can become a tedious process that is easy to forget unless it is incorporated into the build / testing pipeline.

**Suggested Version**

`V4.0.0-beta.6`

**Example Usage**

N/A
