### PR TITLE
Rename package-specific unit options to include package name.

### DIFF
--- a/v4/best_effort_unit_test.go
+++ b/v4/best_effort_unit_test.go
@@ -135,8 +135,8 @@ func (s *BestEffortUnitTestSuite) Setup() {
 	var err error
 	opts := []work.UnitOption{
 		work.UnitDataMappers(dm),
-		work.UnitLogger(l),
-		work.UnitScope(ts),
+		work.UnitZapLogger(l),
+		work.UnitTallyMetricScope(ts),
 		work.UnitRetryAttempts(s.retryCount),
 	}
 	s.sut, err = work.NewUnit(opts...)

--- a/v4/sql_unit_test.go
+++ b/v4/sql_unit_test.go
@@ -134,8 +134,8 @@ func (s *SQLUnitTestSuite) Setup() {
 	s.scope = ts
 	opts := []work.UnitOption{
 		work.UnitDataMappers(dm),
-		work.UnitLogger(l),
-		work.UnitScope(ts),
+		work.UnitZapLogger(l),
+		work.UnitTallyMetricScope(ts),
 		work.UnitDB(s.db),
 		work.UnitRetryAttempts(s.retryCount),
 	}

--- a/v4/unit/alias.go
+++ b/v4/unit/alias.go
@@ -68,10 +68,10 @@ var (
 	// DataMappers specifies the option to provide the data mappers for
 	// the work unit.
 	DataMappers = work.UnitDataMappers
-	// Logger specifies the option to provide a logger for the work unit.
-	Logger = work.UnitLogger
-	// Scope specifies the option to provide a metric scope for the work unit.
-	Scope = work.UnitScope
+	// ZapLogger specifies the option to provide a zap logger for the work unit.
+	ZapLogger = work.UnitZapLogger
+	// TallyMetricScope specifies the option to provide a tally metric scope for the work unit.
+	TallyMetricScope = work.UnitTallyMetricScope
 	// AfterRegisterActions specifies the option to provide actions to execute
 	// after entities are registered with the work unit.
 	AfterRegisterActions = work.UnitAfterRegisterActions

--- a/v4/unit_options.go
+++ b/v4/unit_options.go
@@ -128,7 +128,8 @@ var (
 		}
 	}
 
-	// UnitDataMappers specifies the option to provide the data mappers for the work unit.
+	// UnitDataMappers specifies the option to provide the data mappers for
+	// the work unit.
 	UnitDataMappers = func(dm map[TypeName]UnitDataMapper) UnitOption {
 		return func(o *UnitOptions) {
 			if dm == nil || len(dm) == 0 {
@@ -154,15 +155,17 @@ var (
 		}
 	}
 
-	// UnitLogger specifies the option to provide a logger for the work unit.
-	UnitLogger = func(l *zap.Logger) UnitOption {
+	// UnitZapLogger specifies the option to provide a zap logger for the
+	// work unit.
+	UnitZapLogger = func(l *zap.Logger) UnitOption {
 		return func(o *UnitOptions) {
 			o.logger = l
 		}
 	}
 
-	// UnitScope specifies the option to provide a metric scope for the work unit.
-	UnitScope = func(s tally.Scope) UnitOption {
+	// UnitTallyMetricScope specifies the option to provide a tally metric
+	// scope for the work unit.
+	UnitTallyMetricScope = func(s tally.Scope) UnitOption {
 		return func(o *UnitOptions) {
 			o.scope = s
 		}

--- a/v4/unit_options_test.go
+++ b/v4/unit_options_test.go
@@ -124,7 +124,7 @@ func (s *UnitOptionsTestSuite) TestUnitLogger() {
 	l, _ := c.Build()
 
 	// action.
-	UnitLogger(l)(s.sut)
+	UnitZapLogger(l)(s.sut)
 
 	// assert.
 	s.Equal(l, s.sut.logger)
@@ -135,7 +135,7 @@ func (s *UnitOptionsTestSuite) TestUnitScope() {
 	ts := tally.NewTestScope("test", map[string]string{})
 
 	// action.
-	UnitScope(ts)(s.sut)
+	UnitTallyMetricScope(ts)(s.sut)
 
 	// assert.
 	s.Equal(ts, s.sut.scope)

--- a/v4/unit_test.go
+++ b/v4/unit_test.go
@@ -79,7 +79,7 @@ func (s *UnitTestSuite) SetupTest() {
 	ts := tally.NewTestScope(s.scopePrefix, map[string]string{})
 	s.scope = ts
 	var err error
-	opts := []work.UnitOption{work.UnitDataMappers(dm), work.UnitLogger(l), work.UnitScope(ts)}
+	opts := []work.UnitOption{work.UnitDataMappers(dm), work.UnitZapLogger(l), work.UnitTallyMetricScope(ts)}
 	s.sut, err = work.NewUnit(opts...)
 	s.Require().NoError(err)
 }


### PR DESCRIPTION
**Description**

Renames the `work.UnitLogger` and `work.UnitScope` to `work.UnitZapLogger` and `work.UnitTallyMetricScope`.

**Rationale**

Ideally, this project would not be biased towards particular logging or metric emitting packages. The truth is, the Golang community has not (yet) come to consensus on de-facto standards and the standard library has not been enriched enough to provide common logging and metric emission and interfaces.

That said, it does seem there has been some steam behind an effort to do so, these third party packages have taken more strides to attempt to build in adapters, etc.

We should ensure that we reserve `work.UnitLogger` and `work.UnitMetricScope` for these generic solutions when they arrive.

**Suggested Version**

`v4.0.0-beta.6`

**Example Usage**

```golang
// create logger.
l, _ := zap.NewDevelopment()
s := //...

opts = []unit.Option{
	unit.DB(db),
	unit.DataMappers(m),
	unit.ZapLogger(l), // 🎉
	unit.TallyMetricScope(s), // 🎉
}
u, err := unit.New(opts...)
```
