### PR TITLE
Include go versions 1.20 and 1.21 in CI.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19' ]
+        go-version:
+          [
+            "1.13",
+            "1.14",
+            "1.15",
+            "1.16",
+            "1.17",
+            "1.18",
+            "1.19",
+            "1.20",
+            "1.21",
+          ]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Go ${{ matrix.go-version }}
@@ -30,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.18', '1.19' ]
+        go-version: ["1.18", "1.19", "1.20", "1.21"]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Go ${{ matrix.go-version }}


### PR DESCRIPTION
**Description**

Adjust CI to include `1.20` and `1.21` in the matrix.

**Rationale**

We want to ensure that everything is compatible with the latest versions of Go!

**Suggested Version**

N/A

**Example Usage**

N/A
