### PR TITLE
Add CI support for 1.22.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,7 @@ jobs:
             "1.19",
             "1.20",
             "1.21",
+            "1.22",
           ]
     steps:
       - uses: actions/checkout@v3
@@ -41,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.18", "1.19", "1.20", "1.21"]
+        go-version: ["1.18", "1.19", "1.20", "1.21", "1.22"]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Go ${{ matrix.go-version }}


### PR DESCRIPTION
**Description**

These changes introduce CI support for Go version 1.22.

**Rationale**

We should be testing this library against recent Go versions.

**Suggested Version**

N/A

**Example Usage**

N/A
