### PR TITLE
Drop support for 1.18 in v4 CI.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.18", "1.19", "1.20", "1.21", "1.22"]
+        go-version: ["1.19", "1.20", "1.21", "1.22"]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Go ${{ matrix.go-version }}


### PR DESCRIPTION
**Description**

We've previously taken the approach to support 4 major Go versions for `V4`. Now that support for `1.22` has been added, we can drop `1.18`. These changes do that.

**Rationale**

This should allow us to do some outstanding dependency upgrades for `v4` that have dropped support for `1.18` and rely on features introduced in `1.19`.

**Suggested Version**

N/A

**Example Usage**

N/A
