### PR TITLE
Utilize 1.22 for benchmark tests.

### DIFF
--- a/.github/workflows/cb.yaml
+++ b/.github/workflows/cb.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.18' ]
+        go-version: ["1.22"]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Go ${{ matrix.go-version }}
@@ -27,11 +27,11 @@ jobs:
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
-          tool: 'go'
+          tool: "go"
           output-file-path: output.txt
           external-data-json-path: ./cache/benchmark-data.json
           fail-on-alert: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-always: true
           comment-on-alert: true
-          alert-comment-cc-users: '@fr33r'
+          alert-comment-cc-users: "@fr33r"


### PR DESCRIPTION
**Description**

These changes update the Go version from `1.18` to `1.22` in our continuous benchmarking suite.

**Rationale**

We dropped support for `1.18` in `v4`, and generally assessing the packages performance against the latest version provides a more accurate depiction of what to expect, especially since the Go community usually only supports two major versions simultaneously.

**Suggested Version**

N/A

**Example Usage**

N/A
