### PR TITLE
Upgrade various Github action versions.

### DIFF
--- a/.github/workflows/cb.yaml
+++ b/.github/workflows/cb.yaml
@@ -12,15 +12,15 @@ jobs:
       matrix:
         go-version: ["1.22"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
       - name: Run benchmark
         run: make benchmark | tee output.txt
       - name: Download previous benchmark data
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./cache
           key: ${{ runner.os }}-benchmark

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,16 +21,16 @@ jobs:
             "1.22",
           ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
       - name: Display Go version
         run: go version
       - name: Run Unit Tests
         run: make tests-v3
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         name: Upload Code Coverage
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -44,16 +44,16 @@ jobs:
       matrix:
         go-version: ["1.19", "1.20", "1.21", "1.22"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
       - name: Display Go version
         run: go version
       - name: Run Unit Tests
         run: make tests-v4
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         name: Upload Code Coverage
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
**Description**

These changes upgrade various Github actions uses in the CI and CB workflows, as the current versions use Node 16 which has been deprecated (EOL).

**Rationale**

Github has indicated that we are using actions that are leveraging an EOL version of Node.

**Suggested Version**

N/A

**Example Usage**

N/A
